### PR TITLE
Fix icon and hardcoded name in worldgen category button

### DIFF
--- a/crates/frontend/locales/locales.yml
+++ b/crates/frontend/locales/locales.yml
@@ -117,6 +117,8 @@ gui:
   en: GUI
 worldgen:
   en: World Generation
+worldgen-short:
+  en: Worldgen
 multiplayer:
   en: Multiplayer
 quests:

--- a/crates/frontend/src/lib.rs
+++ b/crates/frontend/src/lib.rs
@@ -40,6 +40,19 @@ macro_rules! ts {
 }
 pub(crate) use ts;
 
+macro_rules! ts_short {
+    ($id:expr) => {{
+        let short_key = format!("{}-short", $id);
+        let translated = rust_i18n::t!(&short_key);
+        if translated.ends_with("-short") {
+            ts!($id)
+        } else {
+            SharedString::new_static(ustr::ustr(&*translated).as_str())
+        }
+    }};
+}
+pub(crate) use ts_short;
+
 #[derive(rust_embed::RustEmbed)]
 #[folder = "../../assets"]
 #[include = "icons/**/*.svg"]

--- a/crates/frontend/src/pages/modrinth_page.rs
+++ b/crates/frontend/src/pages/modrinth_page.rs
@@ -13,7 +13,7 @@ use schema::{content::ContentSource, loader::Loader, modrinth::{
 use crate::{
     component::{error_alert::ErrorAlert, page_path::PagePath}, entity::{
         DataEntities, instance::InstanceEntries, metadata::{AsMetadataResult, FrontendMetadata, FrontendMetadataResult}
-    }, interface_config::InterfaceConfig, ts, ui
+    }, interface_config::InterfaceConfig, ts, ts_short, ui
 };
 
 pub struct ModrinthSearchPage {
@@ -752,11 +752,7 @@ impl Render for ModrinthSearchPage {
                 .multiple(true)
                 .children(categories.iter().map(|id| {
                     Button::new(*id)
-                        .label(if id == &"worldgen" {
-                            "Worldgen".into()
-                        } else {
-                            ts!(*id)
-                        })
+                        .label(ts_short!(id))
                         .when_some(icon_for(id), |this, icon| {
                             this.icon(Icon::empty().path(icon))
                         })
@@ -819,7 +815,7 @@ fn icon_for(str: &str) -> Option<&'static str> {
         "technology" => Some("icons/hard-drive.svg"),
         "transportation" => Some("icons/truck.svg"),
         "utility" => Some("icons/briefcase.svg"),
-        "world-generation" | "locale" => Some("icons/globe.svg"),
+        "worldgen" | "locale" => Some("icons/globe.svg"),
         "audio" => Some("icons/headphones.svg"),
         "blocks" | "rift" => Some("icons/box.svg"),
         "core-shaders" => Some("icons/cpu.svg"),


### PR DESCRIPTION
- Moved hardcoded worldgen name to locales
- Fixed missing icon on the worldgen mod category button
<img width="198" height="88" alt="Missing icon screenshot" src="https://github.com/user-attachments/assets/fc26f1ad-67bb-44ab-9304-fb51df6de34e" />