### PR TITLE
[Feature] Add Support for Waywall and similar programs

### DIFF
--- a/crates/backend/src/backend.rs
+++ b/crates/backend/src/backend.rs
@@ -1068,6 +1068,7 @@ impl BackendState {
             loader,
             preferred_loader_version: None,
             memory: None,
+            wrapper_command: None,
             jvm_flags: None,
             jvm_binary: None,
             linux_wrapper: None,

--- a/crates/backend/src/backend_handler.rs
+++ b/crates/backend/src/backend_handler.rs
@@ -112,6 +112,13 @@ impl BackendState {
                     });
                 }
             },
+            MessageToBackend::SetInstanceWrapperCommand { id, wrapper_command } => {
+                if let Some(instance) = self.instance_state.write().instances.get_mut(id) {
+                    instance.configuration.modify(|configuration| {
+                        configuration.wrapper_command = Some(wrapper_command);
+                    });
+                }
+            },
             MessageToBackend::SetInstanceJvmFlags { id, jvm_flags } => {
                 if let Some(instance) = self.instance_state.write().instances.get_mut(id) {
                     instance.configuration.modify(|configuration| {

--- a/crates/bridge/src/message.rs
+++ b/crates/bridge/src/message.rs
@@ -8,7 +8,7 @@ use enumset::{EnumSet, EnumSetType};
 use schema::{
     backend_config::{BackendConfig, SyncTarget}, instance::{
         InstanceConfiguration, InstanceJvmBinaryConfiguration, InstanceJvmFlagsConfiguration,
-        InstanceLinuxWrapperConfiguration, InstanceMemoryConfiguration, InstanceSystemLibrariesConfiguration,
+        InstanceLinuxWrapperConfiguration, InstanceMemoryConfiguration, InstanceSystemLibrariesConfiguration, InstanceWrapperCommandConfiguration,
     }, loader::Loader, pandora_update::{UpdateManifest, UpdateManifestExe, UpdatePrompt}
 };
 use ustr::Ustr;
@@ -55,6 +55,10 @@ pub enum MessageToBackend {
     SetInstanceMemory {
         id: InstanceID,
         memory: InstanceMemoryConfiguration,
+    },
+    SetInstanceWrapperCommand {
+        id: InstanceID,
+        wrapper_command: InstanceWrapperCommandConfiguration,
     },
     SetInstanceJvmFlags {
         id: InstanceID,

--- a/crates/frontend/locales/locales.yml
+++ b/crates/frontend/locales/locales.yml
@@ -399,6 +399,8 @@ instance:
   # Advanced Settings
   memory:
     en: Set Memory
+  wrapper_command:
+    en: Add Wrapper Command
   jvm_flags:
     en: Add JVM Flags
   jvm_binary:
@@ -424,6 +426,8 @@ instance:
       en: Use GameMode
     use_discrete_gpu:
       en: Use Discrete GPU
+    disable_gl_threaded_optimizations:
+      en: Disable GL Threaded Optimizations
 
   # Delete Dialog
   delete_dialog:

--- a/crates/frontend/src/pages/instance/settings_subpage.rs
+++ b/crates/frontend/src/pages/instance/settings_subpage.rs
@@ -8,7 +8,7 @@ use gpui_component::{
     button::{Button, ButtonGroup, ButtonVariants}, checkbox::Checkbox, h_flex, input::{Input, InputEvent, InputState, NumberInput, NumberInputEvent}, notification::{Notification, NotificationType}, select::{SearchableVec, Select, SelectEvent, SelectState}, skeleton::Skeleton, spinner::Spinner, v_flex, ActiveTheme as _, Disableable, Selectable, Sizable, WindowExt
 };
 use once_cell::sync::Lazy;
-use schema::{fabric_loader_manifest::FabricLoaderManifest, forge::{ForgeMavenManifest, NeoforgeMavenManifest}, instance::{InstanceJvmBinaryConfiguration, InstanceJvmFlagsConfiguration, InstanceLinuxWrapperConfiguration, InstanceMemoryConfiguration, InstanceSystemLibrariesConfiguration, LwjglLibraryPath, AUTO_LIBRARY_PATH_GLFW, AUTO_LIBRARY_PATH_OPENAL}, loader::Loader, version_manifest::MinecraftVersionManifest};
+use schema::{fabric_loader_manifest::FabricLoaderManifest, forge::{ForgeMavenManifest, NeoforgeMavenManifest}, instance::{AUTO_LIBRARY_PATH_GLFW, AUTO_LIBRARY_PATH_OPENAL, InstanceJvmBinaryConfiguration, InstanceJvmFlagsConfiguration, InstanceLinuxWrapperConfiguration, InstanceMemoryConfiguration, InstanceSystemLibrariesConfiguration, InstanceWrapperCommandConfiguration, LwjglLibraryPath}, loader::Loader, version_manifest::MinecraftVersionManifest};
 use strum::IntoEnumIterator;
 
 use crate::{entity::{DataEntities, instance::InstanceEntry, metadata::{AsMetadataResult, FrontendMetadata, FrontendMetadataResult, FrontendMetadataState, TypelessFrontendMetadataResult}}, interface_config::InterfaceConfig, pages::instances_page::VersionList, ts};
@@ -34,6 +34,8 @@ pub struct InstanceSettingsSubpage {
     memory_override_enabled: bool,
     memory_min_input_state: Entity<InputState>,
     memory_max_input_state: Entity<InputState>,
+    wrapper_command_enabled: bool,
+    wrapper_command_input_state: Entity<InputState>,
     jvm_flags_enabled: bool,
     jvm_flags_input_state: Entity<InputState>,
     jvm_binary_enabled: bool,
@@ -50,6 +52,8 @@ pub struct InstanceSettingsSubpage {
     use_gamemode: bool,
     #[cfg(target_os = "linux")]
     use_discrete_gpu: bool,
+    #[cfg(target_os = "linux")]
+    disable_gl_threaded_optimizations: bool,
     #[cfg(target_os = "linux")]
     mangohud_available: bool,
     #[cfg(target_os = "linux")]
@@ -74,6 +78,7 @@ impl InstanceSettingsSubpage {
         let preferred_loader_version = entry.configuration.preferred_loader_version.map(|s| s.as_str()).unwrap_or("Latest");
 
         let memory = entry.configuration.memory.unwrap_or_default();
+        let wrapper_command = entry.configuration.wrapper_command.clone().unwrap_or_default();
         let jvm_flags = entry.configuration.jvm_flags.clone().unwrap_or_default();
         let jvm_binary = entry.configuration.jvm_binary.clone().unwrap_or_default();
         #[cfg(target_os = "linux")]
@@ -132,6 +137,11 @@ impl InstanceSettingsSubpage {
         cx.subscribe_in(&memory_max_input_state, window, Self::on_memory_step).detach();
         cx.subscribe(&memory_max_input_state, Self::on_memory_changed).detach();
 
+        let wrapper_command_input_state = cx.new(|cx| {
+            InputState::new(window, cx).auto_grow(1, 8).default_value(wrapper_command.flags)
+        });
+        cx.subscribe(&wrapper_command_input_state, Self::on_wrapper_command_changed).detach();
+
         let jvm_flags_input_state = cx.new(|cx| {
             InputState::new(window, cx).auto_grow(1, 8).default_value(jvm_flags.flags)
         });
@@ -150,6 +160,8 @@ impl InstanceSettingsSubpage {
             memory_override_enabled: memory.enabled,
             memory_min_input_state,
             memory_max_input_state,
+            wrapper_command_enabled: wrapper_command.enabled,
+            wrapper_command_input_state,
             jvm_flags_enabled: jvm_flags.enabled,
             jvm_flags_input_state,
             jvm_binary_enabled: jvm_binary.enabled,
@@ -164,6 +176,8 @@ impl InstanceSettingsSubpage {
             use_gamemode: linux_wrapper.use_gamemode,
             #[cfg(target_os = "linux")]
             use_discrete_gpu: linux_wrapper.use_discrete_gpu,
+            #[cfg(target_os = "linux")]
+            disable_gl_threaded_optimizations: linux_wrapper.disable_gl_threaded_optimizations,
             #[cfg(target_os = "linux")]
             mangohud_available: Self::is_command_available("mangohud"),
             #[cfg(target_os = "linux")]
@@ -451,6 +465,29 @@ impl InstanceSettingsSubpage {
         }
     }
 
+    pub fn on_wrapper_command_changed(
+        &mut self,
+        _: Entity<InputState>,
+        event: &InputEvent,
+        cx: &mut Context<Self>,
+    ) {
+        if let InputEvent::Change = event {
+            self.backend_handle.send(MessageToBackend::SetInstanceWrapperCommand {
+                id: self.instance_id,
+                wrapper_command: self.get_wrapper_command_configuration(cx)
+            });
+        }
+    }
+
+    fn get_wrapper_command_configuration(&self, cx: &App) -> InstanceWrapperCommandConfiguration {
+        let flags = self.wrapper_command_input_state.read(cx).value();
+
+        InstanceWrapperCommandConfiguration {
+            enabled: self.wrapper_command_enabled,
+            flags: flags.into(),
+        }
+    }
+
     pub fn on_jvm_flags_changed(
         &mut self,
         _: Entity<InputState>,
@@ -508,6 +545,7 @@ impl InstanceSettingsSubpage {
             use_mangohud: self.use_mangohud,
             use_gamemode: self.use_gamemode,
             use_discrete_gpu: self.use_discrete_gpu,
+            disable_gl_threaded_optimizations: self.disable_gl_threaded_optimizations
         }
     }
 
@@ -566,6 +604,7 @@ impl Render for InstanceSettingsSubpage {
             .child(div().text_lg().child(ts!("settings.title")));
 
         let memory_override_enabled = self.memory_override_enabled;
+        let wrapper_command_enabled = self.wrapper_command_enabled;
         let jvm_flags_enabled = self.jvm_flags_enabled;
         let jvm_binary_enabled = self.jvm_binary_enabled;
 
@@ -671,6 +710,19 @@ impl Render for InstanceSettingsSubpage {
                         .child(ts!("common.min"))
                         .child(ts!("common.max")))
                 )
+            ).child(v_flex()
+                .gap_1()
+                .child(Checkbox::new("wrapper_command").label(ts!("instance.wrapper_command")).checked(wrapper_command_enabled).on_click(cx.listener(|page, value, _, cx| {
+                    if page.wrapper_command_enabled != *value {
+                        page.wrapper_command_enabled = *value;
+                        page.backend_handle.send(MessageToBackend::SetInstanceWrapperCommand {
+                            id: page.instance_id,
+                            wrapper_command: page.get_wrapper_command_configuration(cx)
+                        });
+                        cx.notify();
+                    }
+                })))
+                .child(Input::new(&self.wrapper_command_input_state).disabled(!wrapper_command_enabled))
             ).child(v_flex()
                 .gap_1()
                 .child(Checkbox::new("jvm_flags").label(ts!("instance.jvm_flags")).checked(jvm_flags_enabled).on_click(cx.listener(|page, value, _, cx| {
@@ -780,6 +832,16 @@ impl Render for InstanceSettingsSubpage {
             .child(Checkbox::new("use_discrete_gpu").label(ts!("instance.linux.use_discrete_gpu")).checked(self.use_discrete_gpu).on_click(cx.listener(|page, value, _, cx| {
                 if page.use_discrete_gpu != *value {
                     page.use_discrete_gpu = *value;
+                    page.backend_handle.send(MessageToBackend::SetInstanceLinuxWrapper {
+                        id: page.instance_id,
+                        linux_wrapper: page.get_linux_wrapper_configuration()
+                    });
+                    cx.notify();
+                }
+            })))
+            .child(Checkbox::new("disable_gl_threaded_optimizations").label(ts!("instance.linux.disable_gl_threaded_optimizations")).checked(self.disable_gl_threaded_optimizations).on_click(cx.listener(|page, value, _, cx| {
+                if page.disable_gl_threaded_optimizations != *value {
+                    page.disable_gl_threaded_optimizations = *value;
                     page.backend_handle.send(MessageToBackend::SetInstanceLinuxWrapper {
                         id: page.instance_id,
                         linux_wrapper: page.get_linux_wrapper_configuration()

--- a/crates/schema/src/instance.rs
+++ b/crates/schema/src/instance.rs
@@ -14,6 +14,8 @@ pub struct InstanceConfiguration {
     pub preferred_loader_version: Option<Ustr>,
     #[serde(default, deserialize_with = "crate::try_deserialize", skip_serializing_if = "is_default_memory_configuration")]
     pub memory: Option<InstanceMemoryConfiguration>,
+    #[serde(default, deserialize_with = "crate::try_deserialize", skip_serializing_if = "is_default_wrapper_command_configuration")]
+    pub wrapper_command: Option<InstanceWrapperCommandConfiguration>,
     #[serde(default, deserialize_with = "crate::try_deserialize", skip_serializing_if = "is_default_jvm_flags_configuration")]
     pub jvm_flags: Option<InstanceJvmFlagsConfiguration>,
     #[serde(default, deserialize_with = "crate::try_deserialize", skip_serializing_if = "is_default_jvm_binary_configuration")]
@@ -33,6 +35,7 @@ impl InstanceConfiguration {
             loader,
             preferred_loader_version: None,
             memory: None,
+            wrapper_command: None,
             jvm_flags: None,
             jvm_binary: None,
             linux_wrapper: None,
@@ -75,6 +78,20 @@ fn is_default_memory_configuration(config: &Option<InstanceMemoryConfiguration>)
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct InstanceWrapperCommandConfiguration {
+    pub enabled: bool,
+    pub flags: Arc<str>,
+}
+
+fn is_default_wrapper_command_configuration(config: &Option<InstanceWrapperCommandConfiguration>) -> bool {
+    if let Some(config) = config {
+        !config.enabled && config.flags.trim_ascii().is_empty()
+    } else {
+        true
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct InstanceJvmFlagsConfiguration {
     pub enabled: bool,
     pub flags: Arc<str>,
@@ -110,6 +127,8 @@ pub struct InstanceLinuxWrapperConfiguration {
     pub use_gamemode: bool,
     #[serde(default = "crate::default_true", deserialize_with = "crate::try_deserialize")]
     pub use_discrete_gpu: bool,
+    #[serde(default, deserialize_with = "crate::try_deserialize")]
+    pub disable_gl_threaded_optimizations: bool,
 }
 
 impl Default for InstanceLinuxWrapperConfiguration {
@@ -118,13 +137,14 @@ impl Default for InstanceLinuxWrapperConfiguration {
             use_mangohud: false,
             use_gamemode: false,
             use_discrete_gpu: true,
+            disable_gl_threaded_optimizations: false
         }
     }
 }
 
 fn is_default_linux_wrapper_configuration(config: &Option<InstanceLinuxWrapperConfiguration>) -> bool {
     if let Some(config) = config {
-        !config.use_mangohud && !config.use_gamemode && config.use_discrete_gpu
+        !config.use_mangohud && !config.use_gamemode && config.use_discrete_gpu && !config.disable_gl_threaded_optimizations
     } else {
         true
     }


### PR DESCRIPTION
Waywall is a Wayland compositor for Minecraft speedrunning which wraps the game to add support for embedding NinjaBrainBot for finding strongholds and resolution hotkeying. 

To support Waywall two features were added as instance configurations:
 - Add `Wrapper Command` (`mangohud`/`gamemoderun` wrap this when enabled)
 - Add `Disable GL Threaded Optimizations` (Linux Only: Fix for a crash with Nvidia GPUs on Wayland)
 
 
Those who want to use Waywall would do the following to an instance:
- `Add Wrapper Command`: `waywall wrap --`
- Set `Use System GLFW` to Waywall's patched GLFW
- Check `Disable GL Threaded Optimizations`