### PR TITLE
Fix panic when reading log files with invalid UTF8

### DIFF
--- a/crates/backend/src/backend_handler.rs
+++ b/crates/backend/src/backend_handler.rs
@@ -744,7 +744,7 @@ impl BackendState {
                                             let error = format!("Invalid UTF8: {e}");
                                             for line in error.split('\n') {
                                                 let replaced = log_reader::replace(line.trim_ascii_end());
-                                                if send.blocking_send(factory.create(&replaced)).is_err() {
+                                                if send.send(factory.create(&replaced)).await.is_err() {
                                                     return;
                                                 }
                                             }
@@ -757,7 +757,7 @@ impl BackendState {
                                     let error = format!("Error while reading file: {e}");
                                     for line in error.split('\n') {
                                         let replaced = log_reader::replace(line.trim_ascii_end());
-                                        if send.blocking_send(factory.create(&replaced)).is_err() {
+                                        if send.send(factory.create(&replaced)).await.is_err() {
                                             return;
                                         }
                                     }


### PR DESCRIPTION
Fixes a panic that occurred when reading log files containing invalid UTF8 characters or encountering I/O errors:

Backend panicked at crates\backend\src\backend_handler.rs:747:57
Cannot block the current thread from within a runtime.

It seems like this mostly happens with Forge versions below 1.20.6.

