### PR TITLE
Add profile page with interactive 3D skin viewer and Mojang skin upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6326,6 +6326,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ paste = "1.0.15"
 quick-xml = "0.38.3"
 rand = "0.8.5"
 regex = "1.12.2"
-reqwest = { version = "0.12.24", features = ["json", "rustls-tls", "stream"] }
+reqwest = { version = "0.12.24", features = ["json", "multipart", "rustls-tls", "stream"] }
 rust-embed = "8.7.2"
 rustc-hash = "2.1.1"
 sanitize-filename = "0.6.0"

--- a/crates/backend/src/backend.rs
+++ b/crates/backend/src/backend.rs
@@ -18,6 +18,7 @@ use parking_lot::RwLock;
 use reqwest::{StatusCode, redirect::Policy};
 use rustc_hash::{FxHashMap, FxHashSet};
 use schema::{auxiliary::AuxiliaryContentMeta, backend_config::{BackendConfig, SyncTargets, ProxyConfig}, instance::InstanceConfiguration, loader::Loader, modrinth::ModrinthSideRequirement};
+use serde::{Deserialize, Serialize};
 use sha1::{Digest, Sha1};
 use strum::IntoEnumIterator;
 use tokio::sync::{mpsc::Receiver, OnceCell};
@@ -130,6 +131,9 @@ pub fn start(launcher_dir: PathBuf, send: FrontendHandle, self_handle: BackendHa
     // Load accounts
     let account_info = Persistent::load(directories.accounts_json.clone());
 
+    // Load skin history
+    let skin_history = Persistent::load(directories.skin_history_json.clone());
+
     let mut state = BackendState {
         self_handle,
         send: send.clone(),
@@ -145,6 +149,7 @@ pub fn start(launcher_dir: PathBuf, send: FrontendHandle, self_handle: BackendHa
         config: Arc::new(RwLock::new(config)),
         secret_storage: Arc::new(OnceCell::new()),
         head_cache: Default::default(),
+        skin_history: Arc::new(RwLock::new(skin_history)),
     };
 
     log::debug!("Doing initial backend load");
@@ -200,7 +205,8 @@ pub struct BackendState {
     pub account_info: Arc<RwLock<Persistent<BackendAccountInfo>>>,
     pub config: Arc<RwLock<Persistent<BackendConfig>>>,
     pub secret_storage: Arc<OnceCell<Result<PlatformSecretStorage, SecretStorageError>>>,
-    pub head_cache: Arc<RwLock<FxHashMap<Arc<str>, HeadCacheEntry>>>
+    pub head_cache: Arc<RwLock<FxHashMap<Arc<str>, HeadCacheEntry>>>,
+    pub skin_history: Arc<RwLock<Persistent<SkinHistory>>>,
 }
 
 pub enum HeadCacheEntry {
@@ -211,6 +217,47 @@ pub enum HeadCacheEntry {
         head: Arc<[u8]>,
     },
     Failed,
+}
+
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct SkinHistory {
+    pub entries: HashMap<String, Vec<SkinHistoryEntryStored>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkinHistoryEntryStored {
+    pub source_name: String,
+    pub timestamp: i64,
+    pub head_png: Vec<u8>,
+    #[serde(default)]
+    pub skin_png: Vec<u8>,
+    #[serde(default)]
+    pub skin_model: SkinModelStored,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum SkinModelStored {
+    #[default]
+    Classic,
+    Slim,
+}
+
+impl From<bridge::message::SkinModel> for SkinModelStored {
+    fn from(m: bridge::message::SkinModel) -> Self {
+        match m {
+            bridge::message::SkinModel::Classic => SkinModelStored::Classic,
+            bridge::message::SkinModel::Slim => SkinModelStored::Slim,
+        }
+    }
+}
+
+impl From<SkinModelStored> for bridge::message::SkinModel {
+    fn from(m: SkinModelStored) -> Self {
+        match m {
+            SkinModelStored::Classic => bridge::message::SkinModel::Classic,
+            SkinModelStored::Slim => bridge::message::SkinModel::Slim,
+        }
+    }
 }
 
 impl BackendState {
@@ -682,6 +729,251 @@ impl BackendState {
                 }
             });
         });
+    }
+
+    pub async fn fetch_player_skin_by_username(&self, username: &str) -> Result<bridge::message::PlayerSkinResult, Arc<str>> {
+        // Step 1: Look up UUID by username
+        let url = format!("https://api.mojang.com/users/profiles/minecraft/{}", username);
+        let response = self.http_client.get(&url).send().await
+            .map_err(|e| Arc::<str>::from(format!("Failed to look up player: {}", e)))?;
+
+        if !response.status().is_success() {
+            return Err(Arc::from(format!("Player '{}' not found", username)));
+        }
+
+        let body = response.bytes().await
+            .map_err(|e| Arc::<str>::from(format!("Failed to read response: {}", e)))?;
+
+        #[derive(Deserialize)]
+        struct MojangUuidLookup {
+            id: String,
+            name: String,
+        }
+
+        let lookup: MojangUuidLookup = serde_json::from_slice(&body)
+            .map_err(|e| Arc::<str>::from(format!("Failed to parse response: {}", e)))?;
+
+        // Parse UUID (Mojang returns it without dashes)
+        let uuid = Uuid::try_parse(&lookup.id)
+            .map_err(|e| Arc::<str>::from(format!("Invalid UUID: {}", e)))?;
+
+        // Step 2: Get session profile with textures
+        let session_url = format!("https://sessionserver.mojang.com/session/minecraft/profile/{}", lookup.id);
+        let session_response = self.http_client.get(&session_url).send().await
+            .map_err(|e| Arc::<str>::from(format!("Failed to get profile: {}", e)))?;
+
+        if !session_response.status().is_success() {
+            return Err(Arc::from(format!("Failed to get profile for '{}'", username)));
+        }
+
+        let session_body = session_response.bytes().await
+            .map_err(|e| Arc::<str>::from(format!("Failed to read session response: {}", e)))?;
+
+        #[derive(Deserialize)]
+        struct SessionProfile {
+            properties: Vec<SessionProperty>,
+        }
+
+        #[derive(Deserialize)]
+        struct SessionProperty {
+            name: String,
+            value: String,
+        }
+
+        let profile: SessionProfile = serde_json::from_slice(&session_body)
+            .map_err(|e| Arc::<str>::from(format!("Failed to parse session profile: {}", e)))?;
+
+        // Find the textures property and decode it
+        let textures_prop = profile.properties.iter()
+            .find(|p| p.name == "textures")
+            .ok_or_else(|| Arc::<str>::from("No textures property found"))?;
+
+        let decoded = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, &textures_prop.value)
+            .map_err(|e| Arc::<str>::from(format!("Failed to decode textures: {}", e)))?;
+
+        #[derive(Deserialize)]
+        struct TexturesPayload {
+            textures: TexturesMap,
+        }
+
+        #[derive(Deserialize)]
+        struct TexturesMap {
+            #[serde(rename = "SKIN")]
+            skin: Option<TextureSkin>,
+        }
+
+        #[derive(Deserialize)]
+        struct TextureSkin {
+            url: String,
+            #[serde(default)]
+            metadata: Option<TextureSkinMetadata>,
+        }
+
+        #[derive(Deserialize)]
+        struct TextureSkinMetadata {
+            #[serde(default)]
+            model: Option<String>,
+        }
+
+        let payload: TexturesPayload = serde_json::from_slice(&decoded)
+            .map_err(|e| Arc::<str>::from(format!("Failed to parse textures: {}", e)))?;
+
+        let skin = payload.textures.skin
+            .ok_or_else(|| Arc::<str>::from("Player has no skin"))?;
+
+        // Determine skin model (slim if metadata.model == "slim", otherwise classic)
+        let skin_model = if skin.metadata.as_ref().and_then(|m| m.model.as_deref()) == Some("slim") {
+            bridge::message::SkinModel::Slim
+        } else {
+            bridge::message::SkinModel::Classic
+        };
+
+        // Step 3: Download the skin image
+        let skin_response = self.http_client.get(&skin.url).send().await
+            .map_err(|e| Arc::<str>::from(format!("Failed to download skin: {}", e)))?;
+
+        let skin_bytes = skin_response.bytes().await
+            .map_err(|e| Arc::<str>::from(format!("Failed to read skin data: {}", e)))?;
+
+        // Keep the full skin PNG for 3D rendering
+        let full_skin_png: Arc<[u8]> = Arc::from(skin_bytes.as_ref());
+
+        let mut image = image::load_from_memory(&skin_bytes)
+            .map_err(|e| Arc::<str>::from(format!("Failed to load skin image: {}", e)))?;
+
+        // Step 4: Extract head (same logic as update_profile_head)
+        let mut head = image.crop(8, 8, 8, 8);
+        let head_overlay = image.crop(40, 8, 8, 8);
+        image::imageops::overlay(&mut head, &head_overlay, 0, 0);
+
+        let mut head_bytes = Vec::new();
+        let mut cursor = Cursor::new(&mut head_bytes);
+        head.write_to(&mut cursor, image::ImageFormat::Png)
+            .map_err(|e| Arc::<str>::from(format!("Failed to encode head: {}", e)))?;
+
+        Ok(bridge::message::PlayerSkinResult {
+            username: Arc::from(lookup.name.as_str()),
+            uuid,
+            head_png: Arc::from(head_bytes),
+            skin_png: full_skin_png,
+            skin_model,
+        })
+    }
+
+    /// Silently obtain a Minecraft access token by refreshing credentials from the keyring.
+    /// Returns an error if interactive login is required (no refresh token, revoked, etc.).
+    pub async fn get_access_token_silent(&self, uuid: Uuid) -> Result<MinecraftAccessToken, Arc<str>> {
+        let secret_storage = self.secret_storage
+            .get_or_init(PlatformSecretStorage::new)
+            .await
+            .as_ref()
+            .map_err(|e| Arc::<str>::from(format!("Failed to access secret storage: {}", e)))?;
+
+        let mut credentials = secret_storage
+            .read_credentials(uuid)
+            .await
+            .map_err(|e| Arc::<str>::from(format!("Failed to read credentials: {}", e)))?
+            .unwrap_or_default();
+
+        let mut authenticator = Authenticator::new(self.http_client.clone());
+
+        loop {
+            match credentials.stage() {
+                auth::credentials::AuthStageWithData::Initial => {
+                    return Err(Arc::from("You need to log in again to change your skin"));
+                },
+                auth::credentials::AuthStageWithData::MsaRefresh(refresh) => {
+                    match authenticator.refresh_msa(&refresh, &credentials.msa_refresh_force_client_id).await {
+                        Ok(Some(msa_tokens)) => {
+                            credentials.msa_access = Some(msa_tokens.access);
+                            credentials.msa_refresh = msa_tokens.refresh;
+                        },
+                        Ok(None) => {
+                            return Err(Arc::from("Session expired. Please log in again to change your skin"));
+                        },
+                        Err(e) => {
+                            return Err(Arc::from(format!("Authentication failed: {}", e)));
+                        },
+                    }
+                },
+                auth::credentials::AuthStageWithData::MsaAccess(access) => {
+                    match authenticator.authenticate_xbox(&access).await {
+                        Ok(xbl) => {
+                            credentials.xbl = Some(xbl);
+                        },
+                        Err(e) => {
+                            return Err(Arc::from(format!("Xbox authentication failed: {}", e)));
+                        },
+                    }
+                },
+                auth::credentials::AuthStageWithData::XboxLive(xbl) => {
+                    match authenticator.obtain_xsts(&xbl).await {
+                        Ok(xsts) => {
+                            credentials.xsts = Some(xsts);
+                        },
+                        Err(e) => {
+                            return Err(Arc::from(format!("XSTS authentication failed: {}", e)));
+                        },
+                    }
+                },
+                auth::credentials::AuthStageWithData::XboxSecure { xsts, userhash } => {
+                    match authenticator.authenticate_minecraft(&xsts, &userhash).await {
+                        Ok(token) => {
+                            credentials.access_token = Some(token);
+                        },
+                        Err(e) => {
+                            return Err(Arc::from(format!("Minecraft authentication failed: {}", e)));
+                        },
+                    }
+                },
+                auth::credentials::AuthStageWithData::AccessToken(access_token) => {
+                    // Save updated credentials back to keyring
+                    if let Ok(ss) = self.secret_storage.get_or_init(PlatformSecretStorage::new).await.as_ref() {
+                        let _ = ss.write_credentials(uuid, &credentials).await;
+                    }
+                    return Ok(access_token);
+                },
+            }
+        }
+    }
+
+    /// Upload a skin to Mojang's servers.
+    pub async fn upload_skin_to_mojang(
+        &self,
+        access_token: &MinecraftAccessToken,
+        skin_png: &[u8],
+        skin_model: bridge::message::SkinModel,
+    ) -> Result<(), Arc<str>> {
+        let variant = match skin_model {
+            bridge::message::SkinModel::Classic => "classic",
+            bridge::message::SkinModel::Slim => "slim",
+        };
+
+        let form = reqwest::multipart::Form::new()
+            .text("variant", variant.to_string())
+            .part(
+                "file",
+                reqwest::multipart::Part::bytes(skin_png.to_vec())
+                    .file_name("skin.png")
+                    .mime_str("image/png")
+                    .map_err(|e| Arc::<str>::from(format!("Failed to create form part: {}", e)))?,
+            );
+
+        let response = self.http_client
+            .post("https://api.minecraftservices.com/minecraft/profile/skins")
+            .header("Authorization", format!("Bearer {}", access_token.secret()))
+            .multipart(form)
+            .send()
+            .await
+            .map_err(|e| Arc::<str>::from(format!("Failed to upload skin: {}", e)))?;
+
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            Err(Arc::from(format!("Skin upload failed ({}): {}", status, body)))
+        }
     }
 
     pub async fn prelaunch(&self, id: InstanceID, modal_action: &ModalAction) -> Vec<PathBuf> {

--- a/crates/backend/src/backend_handler.rs
+++ b/crates/backend/src/backend_handler.rs
@@ -1260,7 +1260,140 @@ impl BackendState {
             },
             MessageToBackend::ImportFromOtherLauncher { launcher, import_accounts, import_instances, modal_action } => {
                 crate::launcher_import::import_from_other_launcher(self, launcher, import_accounts, import_instances, modal_action).await;
-            }
+            },
+            MessageToBackend::FetchPlayerSkin { username, channel } => {
+                let state = self.clone();
+                tokio::task::spawn(async move {
+                    let result = state.fetch_player_skin_by_username(&username).await;
+                    let _ = channel.send(result);
+                });
+            },
+            MessageToBackend::GetSkinHistory { account_uuid, channel } => {
+                let uuid_str = account_uuid.to_string();
+                let entries = {
+                    let mut skin_history = self.skin_history.write();
+                    let history = skin_history.get();
+                    history.entries.get(&uuid_str).cloned().unwrap_or_default()
+                };
+                let bridge_entries: Vec<bridge::message::SkinHistoryEntry> = entries.into_iter().map(|e| {
+                    bridge::message::SkinHistoryEntry {
+                        source_name: Arc::from(e.source_name.as_str()),
+                        timestamp: e.timestamp,
+                        head_png: Arc::from(e.head_png),
+                        skin_png: Arc::from(e.skin_png),
+                        skin_model: e.skin_model.into(),
+                    }
+                }).collect();
+                let _ = channel.send(bridge_entries);
+            },
+            MessageToBackend::ApplySkin { account_uuid, head_png, skin_png, skin_model, source_name, channel } => {
+                let state = self.clone();
+                tokio::task::spawn(async move {
+                    // Step 1: Authenticate silently to get access token
+                    let access_token = match state.get_access_token_silent(account_uuid).await {
+                        Ok(token) => token,
+                        Err(e) => {
+                            let _ = channel.send(Err(e));
+                            return;
+                        }
+                    };
+
+                    // Step 2: Upload skin to Mojang
+                    if let Err(e) = state.upload_skin_to_mojang(&access_token, &skin_png, skin_model).await {
+                        let _ = channel.send(Err(e));
+                        return;
+                    }
+
+                    // Step 3: Update local account head
+                    {
+                        let mut account_info = state.account_info.write();
+                        account_info.modify(|info| {
+                            if let Some(account) = info.accounts.get_mut(&account_uuid) {
+                                account.head = Some(head_png.clone());
+                            }
+                        });
+                        state.send.send(account_info.get().create_update_message());
+                    }
+
+                    // Step 4: Add to skin history
+                    let uuid_str = account_uuid.to_string();
+                    let timestamp = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs() as i64;
+                    let entry = crate::backend::SkinHistoryEntryStored {
+                        source_name: source_name.to_string(),
+                        timestamp,
+                        head_png: head_png.to_vec(),
+                        skin_png: skin_png.to_vec(),
+                        skin_model: skin_model.into(),
+                    };
+                    let mut skin_history = state.skin_history.write();
+                    skin_history.modify(|history| {
+                        let entries = history.entries.entry(uuid_str).or_default();
+                        entries.insert(0, entry);
+                        entries.truncate(50);
+                    });
+
+                    let _ = channel.send(Ok(()));
+                });
+            },
+            MessageToBackend::ApplySkinFromHistory { account_uuid, history_index, channel } => {
+                let state = self.clone();
+                tokio::task::spawn(async move {
+                    // Step 1: Read skin data from history
+                    let (head_png, skin_png, skin_model) = {
+                        let mut skin_history = state.skin_history.write();
+                        let uuid_str = account_uuid.to_string();
+                        let history = skin_history.get();
+                        match history.entries.get(&uuid_str).and_then(|entries| entries.get(history_index)) {
+                            Some(entry) if !entry.skin_png.is_empty() => {
+                                (
+                                    Arc::<[u8]>::from(entry.head_png.clone()),
+                                    Arc::<[u8]>::from(entry.skin_png.clone()),
+                                    bridge::message::SkinModel::from(entry.skin_model),
+                                )
+                            },
+                            Some(_) => {
+                                let _ = channel.send(Err(Arc::from("This history entry doesn't have skin data (from older version)")));
+                                return;
+                            },
+                            None => {
+                                let _ = channel.send(Err(Arc::from("History entry not found")));
+                                return;
+                            },
+                        }
+                    };
+
+                    // Step 2: Authenticate silently
+                    let access_token = match state.get_access_token_silent(account_uuid).await {
+                        Ok(token) => token,
+                        Err(e) => {
+                            let _ = channel.send(Err(e));
+                            return;
+                        }
+                    };
+
+                    // Step 3: Upload skin to Mojang
+                    if let Err(e) = state.upload_skin_to_mojang(&access_token, &skin_png, skin_model).await {
+                        let _ = channel.send(Err(e));
+                        return;
+                    }
+
+                    // Step 4: Update local account head
+                    {
+                        let mut account_info = state.account_info.write();
+                        account_info.modify(|info| {
+                            if let Some(account) = info.accounts.get_mut(&account_uuid) {
+                                account.head = Some(head_png);
+                            }
+                        });
+                        state.send.send(account_info.get().create_update_message());
+                    }
+
+                    let _ = channel.send(Ok(()));
+                });
+            },
         }
     }
 

--- a/crates/backend/src/directories.rs
+++ b/crates/backend/src/directories.rs
@@ -1,4 +1,7 @@
-use std::{path::{Path, PathBuf}, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 pub struct LauncherDirectories {
     pub instances_dir: Arc<Path>,
@@ -25,6 +28,7 @@ pub struct LauncherDirectories {
     pub root_launcher_dir: Arc<Path>,
     pub config_json: Arc<Path>,
     pub accounts_json: Arc<Path>,
+    pub skin_history_json: Arc<Path>,
 }
 
 impl LauncherDirectories {
@@ -54,6 +58,7 @@ impl LauncherDirectories {
 
         let config_json = launcher_dir.join("config.json");
         let accounts_json = launcher_dir.join("accounts.json");
+        let skin_history_json = launcher_dir.join("skin_history.json");
 
         Self {
             instances_dir: instances_dir.into(),
@@ -80,6 +85,7 @@ impl LauncherDirectories {
             root_launcher_dir: launcher_dir.into(),
             config_json: config_json.into(),
             accounts_json: accounts_json.into(),
+            skin_history_json: skin_history_json.into(),
         }
     }
 }

--- a/crates/bridge/src/message.rs
+++ b/crates/bridge/src/message.rs
@@ -1,25 +1,38 @@
 use std::{
-    collections::BTreeMap, ffi::OsString, path::{Path, PathBuf}, sync::Arc
+    collections::BTreeMap,
+    ffi::OsString,
+    path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use schema::{
-    backend_config::{BackendConfig, ProxyConfig}, instance::{
+    backend_config::{BackendConfig, ProxyConfig},
+    instance::{
         InstanceConfiguration, InstanceJvmBinaryConfiguration, InstanceJvmFlagsConfiguration,
-        InstanceLinuxWrapperConfiguration, InstanceMemoryConfiguration, InstanceSystemLibrariesConfiguration, InstanceWrapperCommandConfiguration,
-    }, loader::Loader, pandora_update::UpdatePrompt
+        InstanceLinuxWrapperConfiguration, InstanceMemoryConfiguration, InstanceSystemLibrariesConfiguration,
+        InstanceWrapperCommandConfiguration,
+    },
+    loader::Loader,
+    pandora_update::UpdatePrompt,
 };
 use ustr::Ustr;
 use uuid::Uuid;
 
 use crate::{
-    account::Account, game_output::GameOutputLogLevel, import::{ImportFromOtherLaunchers, OtherLauncher}, install::ContentInstall, instance::{
+    account::Account,
+    game_output::GameOutputLogLevel,
+    import::{ImportFromOtherLaunchers, OtherLauncher},
+    install::ContentInstall,
+    instance::{
         InstanceContentID, InstanceContentSummary, InstanceID, InstanceServerSummary, InstanceStatus,
         InstanceWorldSummary,
-    }, keep_alive::{KeepAlive, KeepAliveHandle}, meta::{MetadataRequest, MetadataResult}, modal_action::ModalAction
+    },
+    keep_alive::{KeepAlive, KeepAliveHandle},
+    meta::{MetadataRequest, MetadataResult},
+    modal_action::ModalAction,
 };
 
-#[derive(Debug)]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct BackendConfigWithPassword {
     pub config: BackendConfig,
     pub proxy_password: Option<String>,
@@ -45,15 +58,15 @@ pub enum MessageToBackend {
     },
     SetInstanceMinecraftVersion {
         id: InstanceID,
-        version: Ustr
+        version: Ustr,
     },
     SetInstanceLoader {
         id: InstanceID,
-        loader: Loader
+        loader: Loader,
     },
     SetInstancePreferredLoaderVersion {
         id: InstanceID,
-        loader_version: Option<&'static str>
+        loader_version: Option<&'static str>,
     },
     SetInstanceDisableFileSyncing {
         id: InstanceID,
@@ -127,7 +140,7 @@ pub enum MessageToBackend {
     DownloadAllMetadata,
     UpdateCheck {
         instance: InstanceID,
-        modal_action: ModalAction
+        modal_action: ModalAction,
     },
     UpdateContent {
         instance: InstanceID,
@@ -137,7 +150,7 @@ pub enum MessageToBackend {
     Sleep5s,
     ReadLog {
         path: Arc<Path>,
-        send: tokio::sync::mpsc::Sender<Arc<str>>
+        send: tokio::sync::mpsc::Sender<Arc<str>>,
     },
     GetLogFiles {
         instance: InstanceID,
@@ -169,7 +182,7 @@ pub enum MessageToBackend {
     },
     AddOfflineAccount {
         name: Arc<str>,
-        uuid: Uuid
+        uuid: Uuid,
     },
     SelectAccount {
         uuid: Uuid,
@@ -186,11 +199,11 @@ pub enum MessageToBackend {
     },
     CreateInstanceShortcut {
         id: InstanceID,
-        path: PathBuf
+        path: PathBuf,
     },
     RelocateInstance {
         id: InstanceID,
-        path: PathBuf
+        path: PathBuf,
     },
     InstallUpdate {
         update: UpdatePrompt,
@@ -201,7 +214,28 @@ pub enum MessageToBackend {
         import_accounts: bool,
         import_instances: bool,
         modal_action: ModalAction,
-    }
+    },
+    FetchPlayerSkin {
+        username: Arc<str>,
+        channel: tokio::sync::oneshot::Sender<Result<PlayerSkinResult, Arc<str>>>,
+    },
+    GetSkinHistory {
+        account_uuid: Uuid,
+        channel: tokio::sync::oneshot::Sender<Vec<SkinHistoryEntry>>,
+    },
+    ApplySkin {
+        account_uuid: Uuid,
+        head_png: Arc<[u8]>,
+        skin_png: Arc<[u8]>,
+        skin_model: SkinModel,
+        source_name: Arc<str>,
+        channel: tokio::sync::oneshot::Sender<Result<(), Arc<str>>>,
+    },
+    ApplySkinFromHistory {
+        account_uuid: Uuid,
+        history_index: usize,
+        channel: tokio::sync::oneshot::Sender<Result<(), Arc<str>>>,
+    },
 }
 
 #[derive(Debug)]
@@ -345,4 +379,28 @@ pub enum QuickPlayLaunch {
 pub enum EmbeddedOrRaw {
     Embedded(Arc<str>),
     Raw(Arc<[u8]>),
+}
+
+#[derive(Debug, Clone)]
+pub struct PlayerSkinResult {
+    pub username: Arc<str>,
+    pub uuid: Uuid,
+    pub head_png: Arc<[u8]>,
+    pub skin_png: Arc<[u8]>,
+    pub skin_model: SkinModel,
+}
+
+#[derive(Debug, Clone)]
+pub struct SkinHistoryEntry {
+    pub source_name: Arc<str>,
+    pub timestamp: i64,
+    pub head_png: Arc<[u8]>,
+    pub skin_png: Arc<[u8]>,
+    pub skin_model: SkinModel,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkinModel {
+    Classic,
+    Slim,
 }

--- a/crates/frontend/locales/locales.yml
+++ b/crates/frontend/locales/locales.yml
@@ -718,3 +718,49 @@ settings:
       en: Password
     launcher_only_note:
       en: Note - Proxy settings only apply to the launcher, not the game itself
+
+profile:
+  title:
+    en: Profile
+  sidebar:
+    en: Profile & Account
+  current_skin:
+    en: Current Skin
+  no_account:
+    en: No account selected
+  select_account_first:
+    en: Please select an account first to view your profile
+  import_skin:
+    en: Import Skin
+  import_description:
+    en: Enter a Minecraft player username to import their skin
+  username_placeholder:
+    en: Player username
+  fetch:
+    en: Search
+  fetching:
+    en: Searching...
+  apply:
+    en: Apply Skin
+  applying:
+    en: Applying...
+  fetch_error:
+    en: "Error: %{err}"
+  preview:
+    en: Preview
+  skin_history:
+    en: Skin History
+  no_history:
+    en: No skin changes yet
+  from:
+    en: "From: %{name}"
+  revert:
+    en: Revert
+  applied:
+    en: Skin applied successfully
+  uuid_label:
+    en: "UUID: %{uuid}"
+  no_3d_preview:
+    en: No 3D preview available
+  uploading_skin:
+    en: Uploading skin to Mojang...

--- a/crates/frontend/src/component/page_path.rs
+++ b/crates/frontend/src/component/page_path.rs
@@ -1,10 +1,14 @@
 use std::sync::Arc;
 
 use gpui::SharedString;
-use gpui_component::breadcrumb::{Breadcrumb, BreadcrumbItem};
 use gpui::*;
+use gpui_component::breadcrumb::{Breadcrumb, BreadcrumbItem};
 
-use crate::{entity::{DataEntities, instance::InstanceEntries}, ts, ui::PageType};
+use crate::{
+    entity::{instance::InstanceEntries, DataEntities},
+    ts,
+    ui::PageType,
+};
 
 pub struct PagePath {
     pages: Arc<[PageType]>,
@@ -32,6 +36,7 @@ impl PagePath {
                 },
                 PageType::Import => "Import".into(),
                 PageType::Syncing => ts!("instance.sync.label"),
+                PageType::Profile => ts!("profile.title"),
                 PageType::InstancePage(instance_id, _) => {
                     InstanceEntries::find_title_by_id(&data.instances, instance_id, cx)
                         .unwrap_or(ts!("instance.name_placeholder"))
@@ -40,7 +45,7 @@ impl PagePath {
 
             let mut item = BreadcrumbItem::new(title);
 
-            if i < pages.len()-1 {
+            if i < pages.len() - 1 {
                 let pages = pages.clone();
                 item = item.on_click(move |_, window, cx| {
                     let page = pages[i];

--- a/crates/frontend/src/lib.rs
+++ b/crates/frontend/src/lib.rs
@@ -30,6 +30,7 @@ pub mod interface_config;
 pub mod png_render_cache;
 pub mod processor;
 pub mod root;
+pub mod skin_renderer;
 pub mod ui;
 
 rust_i18n::i18n!("locales");

--- a/crates/frontend/src/pages/mod.rs
+++ b/crates/frontend/src/pages/mod.rs
@@ -2,4 +2,5 @@ pub mod instance;
 pub mod import;
 pub mod instances_page;
 pub mod modrinth_page;
+pub mod profile_page;
 pub mod syncing_page;

--- a/crates/frontend/src/pages/profile_page.rs
+++ b/crates/frontend/src/pages/profile_page.rs
@@ -1,0 +1,800 @@
+use std::sync::Arc;
+
+use bridge::{
+    handle::BackendHandle,
+    message::{MessageToBackend, PlayerSkinResult, SkinHistoryEntry, SkinModel},
+};
+use gpui::{prelude::*, *};
+use gpui_component::{
+    button::{Button, ButtonVariants},
+    h_flex,
+    input::{Input, InputState},
+    spinner::Spinner,
+    v_flex,
+    ActiveTheme as _,
+    Disableable,
+    Icon,
+    Sizable,
+    StyledExt,
+};
+use image::Frame;
+
+use crate::{
+    component::page::Page,
+    entity::DataEntities,
+    icon::PandoraIcon,
+    png_render_cache,
+    skin_renderer,
+    ts,
+};
+
+pub struct ProfilePage {
+    data: DataEntities,
+    backend_handle: BackendHandle,
+
+    // Import skin
+    search_input: Entity<InputState>,
+    is_fetching: bool,
+    fetch_result: Option<Result<PlayerSkinResult, Arc<str>>>,
+
+    // 3D rendered preview of fetched skin (cached PNG)
+    fetch_3d_render: Option<Arc<[u8]>>,
+
+    // Current account's 3D skin view
+    current_skin_png: Option<Arc<[u8]>>,       // raw 64x64 skin texture (for re-rendering on rotation)
+    current_skin_3d: Option<Arc<RenderImage>>,  // rendered 3D view (direct GPUI image, no PNG roundtrip)
+    is_loading_current_skin: bool,
+
+    // Rotation state for the current skin viewer
+    skin_yaw: f64,
+    skin_pitch: f64,
+    is_dragging_skin: bool,
+    drag_start_pos: Point<Pixels>,
+    drag_start_yaw: f64,
+    drag_start_pitch: f64,
+
+    // Skin apply state
+    is_applying: bool,
+    apply_error: Option<Arc<str>>,
+
+    // Skin history
+    skin_history: Option<Vec<SkinHistoryEntry>>,
+    _load_history_task: Task<()>,
+    _load_skin_task: Task<()>,
+    _apply_task: Task<()>,
+}
+
+impl ProfilePage {
+    pub fn new(data: &DataEntities, window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let search_input = cx.new(|cx| {
+            InputState::new(window, cx).placeholder(ts!("profile.username_placeholder"))
+        });
+
+        let mut page = Self {
+            data: data.clone(),
+            backend_handle: data.backend_handle.clone(),
+            search_input,
+            is_fetching: false,
+            fetch_result: None,
+            fetch_3d_render: None,
+            current_skin_png: None,
+            current_skin_3d: None,
+            is_loading_current_skin: false,
+            skin_yaw: skin_renderer::DEFAULT_YAW,
+            skin_pitch: skin_renderer::DEFAULT_PITCH,
+            is_dragging_skin: false,
+            drag_start_pos: Point::default(),
+            drag_start_yaw: 0.0,
+            drag_start_pitch: 0.0,
+            is_applying: false,
+            apply_error: None,
+            skin_history: None,
+            _load_history_task: Task::ready(()),
+            _load_skin_task: Task::ready(()),
+            _apply_task: Task::ready(()),
+        };
+
+        page.load_skin_history(cx);
+        page.load_current_skin_3d(cx);
+
+        page
+    }
+
+    fn load_skin_history(&mut self, cx: &mut Context<Self>) {
+        let accounts = self.data.accounts.read(cx);
+        let Some(account) = &accounts.selected_account else {
+            return;
+        };
+        let uuid = account.uuid;
+
+        let (send, recv) = tokio::sync::oneshot::channel();
+        self.backend_handle.send(MessageToBackend::GetSkinHistory {
+            account_uuid: uuid,
+            channel: send,
+        });
+
+        self._load_history_task = cx.spawn(async move |page, cx| {
+            let Ok(entries) = recv.await else { return };
+            let _ = page.update(cx, move |page, cx| {
+                page.skin_history = Some(entries);
+                cx.notify();
+            });
+        });
+    }
+
+    /// Auto-fetch the current account's skin by username for 3D rendering.
+    fn load_current_skin_3d(&mut self, cx: &mut Context<Self>) {
+        let accounts = self.data.accounts.read(cx);
+        let Some(account) = &accounts.selected_account else {
+            return;
+        };
+        let username: Arc<str> = Arc::from(&*account.username);
+
+        self.is_loading_current_skin = true;
+        cx.notify();
+
+        let (send, recv) = tokio::sync::oneshot::channel();
+        self.backend_handle.send(MessageToBackend::FetchPlayerSkin {
+            username,
+            channel: send,
+        });
+
+        let yaw = self.skin_yaw;
+        let pitch = self.skin_pitch;
+
+        self._load_skin_task = cx.spawn(async move |page, cx| {
+            let Ok(result) = recv.await else { return };
+            let _ = page.update(cx, move |page, cx| {
+                page.is_loading_current_skin = false;
+                if let Ok(skin_result) = result {
+                    page.current_skin_png = Some(skin_result.skin_png.clone());
+                    // Render the 3D view from the full skin texture
+                    page.current_skin_3d =
+                        Self::skin_to_render_image(&skin_result.skin_png, 200, 360, yaw, pitch);
+                }
+                cx.notify();
+            });
+        });
+    }
+
+    /// Re-render the current skin 3D view with the current rotation angles.
+    fn re_render_current_skin(&mut self) {
+        if let Some(skin_png) = &self.current_skin_png {
+            self.current_skin_3d =
+                Self::skin_to_render_image(skin_png, 200, 360, self.skin_yaw, self.skin_pitch);
+        }
+    }
+
+    /// Render a skin texture to a GPUI `RenderImage` at the given rotation.
+    /// Bypasses PNG encoding for fast interactive rendering.
+    fn skin_to_render_image(
+        skin_png: &[u8],
+        width: u32,
+        height: u32,
+        yaw: f64,
+        pitch: f64,
+    ) -> Option<Arc<RenderImage>> {
+        let mut output = skin_renderer::render_skin_3d_raw(skin_png, width, height, yaw, pitch)?;
+        // Convert RGBA to BGRA for GPUI
+        for pixel in output.chunks_exact_mut(4) {
+            pixel.swap(0, 2);
+        }
+        Some(Arc::new(RenderImage::new([Frame::new(output)])))
+    }
+
+    fn fetch_skin(&mut self, cx: &mut Context<Self>) {
+        let username = self.search_input.read(cx).value();
+        let username = username.trim();
+        if username.is_empty() {
+            return;
+        }
+
+        self.is_fetching = true;
+        self.fetch_result = None;
+        self.fetch_3d_render = None;
+        cx.notify();
+
+        let username: Arc<str> = Arc::from(username);
+        let (send, recv) = tokio::sync::oneshot::channel();
+
+        self.backend_handle.send(MessageToBackend::FetchPlayerSkin {
+            username,
+            channel: send,
+        });
+
+        cx.spawn(async move |page, cx| {
+            let Ok(result) = recv.await else { return };
+            let _ = page.update(cx, move |page, cx| {
+                page.is_fetching = false;
+                // Pre-render 3D view for fetched skin
+                if let Ok(ref skin_result) = result {
+                    if let Some(rendered) = skin_renderer::render_skin_3d(
+                        &skin_result.skin_png,
+                        160,
+                        280,
+                        skin_renderer::DEFAULT_YAW,
+                        skin_renderer::DEFAULT_PITCH,
+                    ) {
+                        page.fetch_3d_render = Some(Arc::from(rendered));
+                    }
+                }
+                page.fetch_result = Some(result);
+                cx.notify();
+            });
+        })
+        .detach();
+    }
+
+    fn apply_skin(&mut self, head_png: Arc<[u8]>, skin_png: Arc<[u8]>, skin_model: SkinModel, source_name: Arc<str>, cx: &mut Context<Self>) {
+        let accounts = self.data.accounts.read(cx);
+        let Some(account) = &accounts.selected_account else {
+            return;
+        };
+        let uuid = account.uuid;
+
+        self.is_applying = true;
+        self.apply_error = None;
+        cx.notify();
+
+        let (send, recv) = tokio::sync::oneshot::channel();
+        self.backend_handle.send(MessageToBackend::ApplySkin {
+            account_uuid: uuid,
+            head_png,
+            skin_png: skin_png.clone(),
+            skin_model,
+            source_name,
+            channel: send,
+        });
+
+        let skin_png_for_render = skin_png;
+        self._apply_task = cx.spawn(async move |page, cx| {
+            let Ok(result) = recv.await else { return };
+            let _ = page.update(cx, move |page, cx| {
+                page.is_applying = false;
+                match result {
+                    Ok(()) => {
+                        page.apply_error = None;
+                        // Update the 3D skin view with the applied skin's texture
+                        page.current_skin_png = Some(skin_png_for_render);
+                        page.skin_yaw = skin_renderer::DEFAULT_YAW;
+                        page.skin_pitch = skin_renderer::DEFAULT_PITCH;
+                        page.re_render_current_skin();
+                        // Reload history after applying
+                        page.load_skin_history(cx);
+                    },
+                    Err(e) => {
+                        page.apply_error = Some(e);
+                    },
+                }
+                cx.notify();
+            });
+        });
+    }
+
+    fn apply_skin_from_history(&mut self, index: usize, cx: &mut Context<Self>) {
+        let accounts = self.data.accounts.read(cx);
+        let Some(account) = &accounts.selected_account else {
+            return;
+        };
+        let uuid = account.uuid;
+
+        // Get the skin data from history for local preview update on success
+        let history_entry = self.skin_history.as_ref()
+            .and_then(|h| h.get(index))
+            .cloned();
+
+        self.is_applying = true;
+        self.apply_error = None;
+        cx.notify();
+
+        let (send, recv) = tokio::sync::oneshot::channel();
+        self.backend_handle.send(MessageToBackend::ApplySkinFromHistory {
+            account_uuid: uuid,
+            history_index: index,
+            channel: send,
+        });
+
+        self._apply_task = cx.spawn(async move |page, cx| {
+            let Ok(result) = recv.await else { return };
+            let _ = page.update(cx, move |page, cx| {
+                page.is_applying = false;
+                match result {
+                    Ok(()) => {
+                        page.apply_error = None;
+                        // Update 3D view if we have the skin data
+                        if let Some(entry) = history_entry {
+                            if !entry.skin_png.is_empty() {
+                                page.current_skin_png = Some(entry.skin_png);
+                                page.skin_yaw = skin_renderer::DEFAULT_YAW;
+                                page.skin_pitch = skin_renderer::DEFAULT_PITCH;
+                                page.re_render_current_skin();
+                            } else {
+                                // Reload from server if no local skin data
+                                page.load_current_skin_3d(cx);
+                            }
+                        }
+                        page.load_skin_history(cx);
+                    },
+                    Err(e) => {
+                        page.apply_error = Some(e);
+                    },
+                }
+                cx.notify();
+            });
+        });
+    }
+}
+
+impl Render for ProfilePage {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let accounts = self.data.accounts.read(cx);
+        let selected_account = accounts.selected_account.clone();
+
+        let Some(account) = selected_account else {
+            let content = v_flex()
+                .size_full()
+                .p_6()
+                .gap_4()
+                .items_center()
+                .justify_center()
+                .child(
+                    Icon::new(PandoraIcon::CircleUser)
+                        .size_16()
+                        .text_color(cx.theme().muted_foreground),
+                )
+                .child(
+                    div()
+                        .text_lg()
+                        .text_color(cx.theme().muted_foreground)
+                        .child(ts!("profile.select_account_first")),
+                );
+
+            return Page::new(ts!("profile.title")).scrollable().child(content);
+        };
+
+        // Current account head (2D)
+        let account_head = if let Some(head) = &account.head {
+            let resize =
+                png_render_cache::ImageTransformation::Resize {
+                    width: 64,
+                    height: 64,
+                };
+            png_render_cache::render_with_transform(Arc::clone(head), resize, cx)
+        } else {
+            gpui::img(ImageSource::Resource(Resource::Embedded(
+                "images/default_head.png".into(),
+            )))
+        };
+
+        let account_name = SharedString::new(account.username.clone());
+        let account_uuid_str = account.uuid.to_string();
+
+        // 3D skin view (interactive: drag to rotate)
+        let is_dragging = self.is_dragging_skin;
+        let skin_3d_element = if let Some(render_image) = &self.current_skin_3d {
+            let skin_img = gpui::img(render_image.clone());
+            let mut viewer = div()
+                .id("skin-3d-viewer")
+                .rounded(cx.theme().radius)
+                .border_1()
+                .border_color(cx.theme().border)
+                .bg(cx.theme().secondary)
+                .p_3()
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(|page, event: &MouseDownEvent, _window, _cx| {
+                        page.is_dragging_skin = true;
+                        page.drag_start_pos = event.position;
+                        page.drag_start_yaw = page.skin_yaw;
+                        page.drag_start_pitch = page.skin_pitch;
+                    }),
+                )
+                .on_mouse_move(cx.listener(|page, event: &MouseMoveEvent, _window, cx| {
+                    if !page.is_dragging_skin {
+                        return;
+                    }
+                    let dx = event.position.x.to_f64() - page.drag_start_pos.x.to_f64();
+                    let dy = event.position.y.to_f64() - page.drag_start_pos.y.to_f64();
+                    page.skin_yaw = page.drag_start_yaw + dx * 0.5;
+                    page.skin_pitch = (page.drag_start_pitch + dy * 0.3).clamp(-60.0, 60.0);
+                    page.re_render_current_skin();
+                    cx.notify();
+                }))
+                .on_mouse_up(
+                    MouseButton::Left,
+                    cx.listener(|page, _event: &MouseUpEvent, _window, _cx| {
+                        page.is_dragging_skin = false;
+                    }),
+                )
+                .on_mouse_up_out(
+                    MouseButton::Left,
+                    cx.listener(|page, _event: &MouseUpEvent, _window, _cx| {
+                        page.is_dragging_skin = false;
+                    }),
+                );
+            if is_dragging {
+                viewer = viewer.cursor_grabbing();
+            } else {
+                viewer = viewer.cursor_grab();
+            }
+            viewer
+                .child(skin_img.h(px(280.0)).w(px(155.0)))
+                .into_any_element()
+        } else if self.is_loading_current_skin {
+            div()
+                .rounded(cx.theme().radius)
+                .border_1()
+                .border_color(cx.theme().border)
+                .bg(cx.theme().secondary)
+                .p_3()
+                .w(px(155.0))
+                .h(px(280.0))
+                .items_center()
+                .justify_center()
+                .child(Spinner::new())
+                .into_any_element()
+        } else {
+            // No 3D view available (e.g. offline account)
+            div()
+                .rounded(cx.theme().radius)
+                .border_1()
+                .border_color(cx.theme().border)
+                .bg(cx.theme().secondary)
+                .p_3()
+                .w(px(155.0))
+                .h(px(280.0))
+                .items_center()
+                .justify_center()
+                .child(
+                    v_flex()
+                        .gap_2()
+                        .items_center()
+                        .child(
+                            Icon::new(PandoraIcon::CircleUser)
+                                .size_12()
+                                .text_color(cx.theme().muted_foreground),
+                        )
+                        .child(
+                            div()
+                                .text_sm()
+                                .text_color(cx.theme().muted_foreground)
+                                .child(ts!("profile.no_3d_preview")),
+                        ),
+                )
+                .into_any_element()
+        };
+
+        // Account info (to the right of 3D view)
+        let account_info = v_flex()
+            .gap_3()
+            .child(
+                h_flex()
+                    .gap_3()
+                    .items_center()
+                    .child(
+                        div()
+                            .rounded(cx.theme().radius)
+                            .border_1()
+                            .border_color(cx.theme().border)
+                            .p_2()
+                            .child(account_head.size_16().min_w_16().min_h_16()),
+                    )
+                    .child(
+                        v_flex()
+                            .gap_1()
+                            .child(
+                                div()
+                                    .text_lg()
+                                    .font_semibold()
+                                    .child(account_name),
+                            )
+                            .child(
+                                div()
+                                    .text_sm()
+                                    .text_color(cx.theme().muted_foreground)
+                                    .child(ts!("profile.uuid_label", uuid = account_uuid_str)),
+                            ),
+                    ),
+            );
+
+        let current_skin_section = v_flex()
+            .gap_3()
+            .child(
+                div()
+                    .border_b_1()
+                    .border_color(cx.theme().border)
+                    .text_lg()
+                    .font_semibold()
+                    .child(ts!("profile.current_skin")),
+            )
+            .child(
+                h_flex()
+                    .gap_6()
+                    .items_start()
+                    .child(skin_3d_element)
+                    .child(account_info),
+            );
+
+        // Import skin section
+        let search_button = if self.is_fetching {
+            Button::new("fetch-skin")
+                .label(ts!("profile.fetching"))
+                .disabled(true)
+                .child(Spinner::new())
+        } else {
+            Button::new("fetch-skin")
+                .label(ts!("profile.fetch"))
+                .icon(PandoraIcon::Search)
+                .info()
+                .on_click(cx.listener(|page, _, _, cx| {
+                    page.fetch_skin(cx);
+                }))
+        };
+
+        let mut import_section = v_flex()
+            .gap_3()
+            .child(
+                div()
+                    .border_b_1()
+                    .border_color(cx.theme().border)
+                    .text_lg()
+                    .font_semibold()
+                    .child(ts!("profile.import_skin")),
+            )
+            .child(
+                div()
+                    .text_sm()
+                    .text_color(cx.theme().muted_foreground)
+                    .child(ts!("profile.import_description")),
+            )
+            .child(
+                h_flex()
+                    .gap_2()
+                    .child(Input::new(&self.search_input).max_w_80())
+                    .child(search_button),
+            );
+
+        // Show fetch result / preview
+        if let Some(result) = &self.fetch_result {
+            match result {
+                Ok(skin_result) => {
+                    let preview_head = {
+                        let resize = png_render_cache::ImageTransformation::Resize {
+                            width: 64,
+                            height: 64,
+                        };
+                        png_render_cache::render_with_transform(
+                            Arc::clone(&skin_result.head_png),
+                            resize,
+                            cx,
+                        )
+                    };
+
+                    let preview_name = SharedString::new(skin_result.username.clone());
+                    let head_png = skin_result.head_png.clone();
+                    let skin_png = skin_result.skin_png.clone();
+                    let skin_model = skin_result.skin_model;
+                    let source_name = skin_result.username.clone();
+
+                    // Left side: 3D preview (if available)
+                    let preview_3d = if let Some(rendered) = &self.fetch_3d_render {
+                        let img = png_render_cache::render(Arc::clone(rendered), cx);
+                        div()
+                            .rounded(cx.theme().radius)
+                            .border_1()
+                            .border_color(cx.theme().border)
+                            .bg(cx.theme().secondary)
+                            .p_2()
+                            .child(img.h(px(200.0)).w(px(110.0)))
+                    } else {
+                        div()
+                            .rounded(cx.theme().radius)
+                            .p_1()
+                            .child(preview_head.size_12().min_w_12().min_h_12())
+                    };
+
+                    let preview = h_flex()
+                        .gap_4()
+                        .items_center()
+                        .p_3()
+                        .rounded(cx.theme().radius)
+                        .border_1()
+                        .border_color(cx.theme().border)
+                        .bg(cx.theme().secondary)
+                        .child(preview_3d)
+                        .child(
+                            v_flex()
+                                .flex_grow()
+                                .gap_0p5()
+                                .child(div().font_semibold().child(preview_name))
+                                .child(
+                                    div()
+                                        .text_sm()
+                                        .text_color(cx.theme().muted_foreground)
+                                        .child(ts!("profile.preview")),
+                                ),
+                        )
+                        .child(
+                            if self.is_applying {
+                                Button::new("apply-fetched")
+                                    .label(ts!("profile.applying"))
+                                    .disabled(true)
+                                    .child(Spinner::new())
+                                    .into_any_element()
+                            } else {
+                                Button::new("apply-fetched")
+                                    .label(ts!("profile.apply"))
+                                    .icon(PandoraIcon::Download)
+                                    .success()
+                                    .on_click(cx.listener(move |page, _, _, cx| {
+                                        page.apply_skin(head_png.clone(), skin_png.clone(), skin_model, source_name.clone(), cx);
+                                    }))
+                                    .into_any_element()
+                            },
+                        );
+
+                    import_section = import_section.child(preview);
+                }
+                Err(err) => {
+                    let err_msg = ts!("profile.fetch_error", err = err);
+                    import_section = import_section.child(
+                        div()
+                            .p_3()
+                            .rounded(cx.theme().radius)
+                            .border_1()
+                            .border_color(cx.theme().danger)
+                            .text_color(cx.theme().danger)
+                            .text_sm()
+                            .child(err_msg),
+                    );
+                }
+            }
+        }
+
+        // Skin history section
+        let mut history_section = v_flex().gap_3().child(
+            div()
+                .border_b_1()
+                .border_color(cx.theme().border)
+                .text_lg()
+                .font_semibold()
+                .child(ts!("profile.skin_history")),
+        );
+
+        if let Some(history) = &self.skin_history {
+            if history.is_empty() {
+                history_section = history_section.child(
+                    div()
+                        .text_sm()
+                        .text_color(cx.theme().muted_foreground)
+                        .child(ts!("profile.no_history")),
+                );
+            } else {
+                for (index, entry) in history.iter().enumerate() {
+                    let entry_head = {
+                        let resize = png_render_cache::ImageTransformation::Resize {
+                            width: 32,
+                            height: 32,
+                        };
+                        png_render_cache::render_with_transform(
+                            Arc::clone(&entry.head_png),
+                            resize,
+                            cx,
+                        )
+                    };
+
+                    let source_label =
+                        ts!("profile.from", name = entry.source_name.clone());
+
+                    // Format timestamp
+                    let time_str = {
+                        let dt = chrono::DateTime::from_timestamp(entry.timestamp, 0);
+                        if let Some(dt) = dt {
+                            SharedString::from(
+                                dt.format("%Y-%m-%d %H:%M").to_string(),
+                            )
+                        } else {
+                            SharedString::from("Unknown")
+                        }
+                    };
+
+                    let entry_row = h_flex()
+                        .gap_3()
+                        .items_center()
+                        .p_2()
+                        .rounded(cx.theme().radius)
+                        .border_1()
+                        .border_color(cx.theme().border)
+                        .child(
+                            div()
+                                .rounded(cx.theme().radius)
+                                .child(entry_head.size_8().min_w_8().min_h_8()),
+                        )
+                        .child(
+                            v_flex()
+                                .flex_grow()
+                                .gap_0p5()
+                                .child(div().text_sm().font_semibold().child(source_label))
+                                .child(
+                                    div()
+                                        .text_xs()
+                                        .text_color(cx.theme().muted_foreground)
+                                        .child(time_str),
+                                ),
+                        )
+                        .child(
+                            if self.is_applying {
+                                Button::new(("revert", index))
+                                    .label(ts!("profile.revert"))
+                                    .small()
+                                    .disabled(true)
+                                    .into_any_element()
+                            } else if entry.skin_png.is_empty() {
+                                Button::new(("revert", index))
+                                    .label(ts!("profile.revert"))
+                                    .small()
+                                    .disabled(true)
+                                    .into_any_element()
+                            } else {
+                                Button::new(("revert", index))
+                                    .label(ts!("profile.revert"))
+                                    .small()
+                                    .on_click(cx.listener(move |page, _, _, cx| {
+                                        page.apply_skin_from_history(index, cx);
+                                    }))
+                                    .into_any_element()
+                            },
+                        );
+
+                    history_section = history_section.child(entry_row);
+                }
+            }
+        } else {
+            history_section = history_section.child(Spinner::new());
+        }
+
+        let mut content = v_flex()
+            .size_full()
+            .p_6()
+            .gap_6()
+            .child(current_skin_section)
+            .child(import_section);
+
+        // Show apply error if any
+        if let Some(error) = &self.apply_error {
+            let err_msg = SharedString::from(format!("Failed to apply skin: {}", error));
+            content = content.child(
+                div()
+                    .p_3()
+                    .rounded(cx.theme().radius)
+                    .border_1()
+                    .border_color(cx.theme().danger)
+                    .text_color(cx.theme().danger)
+                    .text_sm()
+                    .child(err_msg),
+            );
+        }
+
+        // Show applying indicator
+        if self.is_applying {
+            content = content.child(
+                h_flex()
+                    .gap_2()
+                    .items_center()
+                    .child(Spinner::new())
+                    .child(
+                        div()
+                            .text_sm()
+                            .text_color(cx.theme().muted_foreground)
+                            .child(ts!("profile.uploading_skin")),
+                    ),
+            );
+        }
+
+        content = content.child(history_section);
+
+        Page::new(ts!("profile.title"))
+            .scrollable()
+            .child(content)
+    }
+}

--- a/crates/frontend/src/skin_renderer.rs
+++ b/crates/frontend/src/skin_renderer.rs
@@ -1,0 +1,556 @@
+//! Software 3D renderer for Minecraft player skins.
+//!
+//! Takes a full 64x64 Minecraft skin texture (PNG bytes) and renders an isometric
+//! 3D view of the player model. The output is a PNG image suitable for display
+//! via `png_render_cache`.
+
+use image::{GenericImageView, ImageFormat, Rgba, RgbaImage};
+use std::io::Cursor;
+
+/// Default rotation angles for the initial view.
+pub const DEFAULT_YAW: f64 = 25.0;
+pub const DEFAULT_PITCH: f64 = -20.0;
+
+// ── Math types ──────────────────────────────────────────────────────────────
+
+#[derive(Clone, Copy)]
+struct V3 {
+    x: f64,
+    y: f64,
+    z: f64,
+}
+
+impl V3 {
+    fn new(x: f64, y: f64, z: f64) -> Self {
+        Self { x, y, z }
+    }
+}
+
+/// 3×3 rotation matrix stored as rows.
+struct Mat3([[f64; 3]; 3]);
+
+impl Mat3 {
+    /// Build a combined rotation: first rotate `ry` radians around Y, then `rx` around X.
+    fn rotation_yx(ry: f64, rx: f64) -> Self {
+        let (sy, cy) = ry.sin_cos();
+        let (sx, cx) = rx.sin_cos();
+        // Rx * Ry
+        Self([[cy, 0.0, sy], [sx * sy, cx, -sx * cy], [-cx * sy, sx, cx * cy]])
+    }
+
+    fn transform(&self, v: V3) -> V3 {
+        let r = &self.0;
+        V3 {
+            x: r[0][0] * v.x + r[0][1] * v.y + r[0][2] * v.z,
+            y: r[1][0] * v.x + r[1][1] * v.y + r[1][2] * v.z,
+            z: r[2][0] * v.x + r[2][1] * v.y + r[2][2] * v.z,
+        }
+    }
+}
+
+// ── Quad / face definitions ─────────────────────────────────────────────────
+
+/// A textured quad (face) ready for rendering.
+struct Quad {
+    /// 4 corners in 3D (order: top-left, top-right, bottom-right, bottom-left as seen from outside).
+    verts: [V3; 4],
+    /// Absolute texture pixel coordinates for each corner.
+    uvs: [(f64, f64); 4],
+    /// Outward face normal (before rotation).
+    normal: V3,
+}
+
+/// Generate the 6 face quads for an axis-aligned box.
+///
+/// - `min`/`max`: box corners in model space.
+/// - `tx`, `ty`: top-left corner of this box's texture region in the skin.
+/// - `w`, `h`, `d`: box width (X), height (Y), depth (Z) – must equal max-min.
+fn box_quads(min: V3, max: V3, tx: f64, ty: f64, w: f64, h: f64, d: f64) -> [Quad; 6] {
+    let (x0, y0, z0) = (min.x, min.y, min.z);
+    let (x1, y1, z1) = (max.x, max.y, max.z);
+
+    [
+        // Front face (+Z) – texture region at (tx+d, ty+d) size w×h
+        Quad {
+            verts: [
+                V3::new(x0, y1, z1),
+                V3::new(x1, y1, z1),
+                V3::new(x1, y0, z1),
+                V3::new(x0, y0, z1),
+            ],
+            uvs: [
+                (tx + d, ty + d),
+                (tx + d + w, ty + d),
+                (tx + d + w, ty + d + h),
+                (tx + d, ty + d + h),
+            ],
+            normal: V3::new(0.0, 0.0, 1.0),
+        },
+        // Back face (-Z) – texture at (tx+2d+w, ty+d) size w×h
+        Quad {
+            verts: [
+                V3::new(x1, y1, z0),
+                V3::new(x0, y1, z0),
+                V3::new(x0, y0, z0),
+                V3::new(x1, y0, z0),
+            ],
+            uvs: [
+                (tx + 2.0 * d + w, ty + d),
+                (tx + 2.0 * d + 2.0 * w, ty + d),
+                (tx + 2.0 * d + 2.0 * w, ty + d + h),
+                (tx + 2.0 * d + w, ty + d + h),
+            ],
+            normal: V3::new(0.0, 0.0, -1.0),
+        },
+        // Right face (-X, player's right) – texture at (tx, ty+d) size d×h
+        Quad {
+            verts: [
+                V3::new(x0, y1, z1),
+                V3::new(x0, y1, z0),
+                V3::new(x0, y0, z0),
+                V3::new(x0, y0, z1),
+            ],
+            uvs: [(tx + d, ty + d), (tx, ty + d), (tx, ty + d + h), (tx + d, ty + d + h)],
+            normal: V3::new(-1.0, 0.0, 0.0),
+        },
+        // Left face (+X, player's left) – texture at (tx+d+w, ty+d) size d×h
+        Quad {
+            verts: [
+                V3::new(x1, y1, z0),
+                V3::new(x1, y1, z1),
+                V3::new(x1, y0, z1),
+                V3::new(x1, y0, z0),
+            ],
+            uvs: [
+                (tx + 2.0 * d + w, ty + d),
+                (tx + d + w, ty + d),
+                (tx + d + w, ty + d + h),
+                (tx + 2.0 * d + w, ty + d + h),
+            ],
+            normal: V3::new(1.0, 0.0, 0.0),
+        },
+        // Top face (+Y) – texture at (tx+d, ty) size w×d
+        Quad {
+            verts: [
+                V3::new(x0, y1, z0),
+                V3::new(x1, y1, z0),
+                V3::new(x1, y1, z1),
+                V3::new(x0, y1, z1),
+            ],
+            uvs: [(tx + d, ty), (tx + d + w, ty), (tx + d + w, ty + d), (tx + d, ty + d)],
+            normal: V3::new(0.0, 1.0, 0.0),
+        },
+        // Bottom face (-Y) – texture at (tx+d+w, ty) size w×d
+        Quad {
+            verts: [
+                V3::new(x1, y0, z0),
+                V3::new(x0, y0, z0),
+                V3::new(x0, y0, z1),
+                V3::new(x1, y0, z1),
+            ],
+            uvs: [
+                (tx + d + w, ty),
+                (tx + d + 2.0 * w, ty),
+                (tx + d + 2.0 * w, ty + d),
+                (tx + d + w, ty + d),
+            ],
+            normal: V3::new(0.0, -1.0, 0.0),
+        },
+    ]
+}
+
+// ── Body part definitions ───────────────────────────────────────────────────
+
+struct BodyPartDef {
+    min: V3,
+    max: V3,
+    tx: f64,
+    ty: f64,
+    w: f64,
+    h: f64,
+    d: f64,
+}
+
+/// Returns all body parts (base layer + overlay layer).
+/// The overlay boxes are 0.5 units larger on each side.
+fn player_model() -> Vec<BodyPartDef> {
+    // Player model dimensions (units = skin pixels):
+    //   Legs:  y  0..12,   4 wide, 4 deep
+    //   Body:  y 12..24,   8 wide, 4 deep
+    //   Arms:  y 12..24,   4 wide, 4 deep
+    //   Head:  y 24..32,   8 wide, 8 deep
+    //
+    // Centered at x=0, z=0.
+
+    let e = 0.5; // overlay expansion
+
+    vec![
+        // ── Base layers ──
+        // Head
+        BodyPartDef {
+            min: V3::new(-4.0, 24.0, -4.0),
+            max: V3::new(4.0, 32.0, 4.0),
+            tx: 0.0,
+            ty: 0.0,
+            w: 8.0,
+            h: 8.0,
+            d: 8.0,
+        },
+        // Body
+        BodyPartDef {
+            min: V3::new(-4.0, 12.0, -2.0),
+            max: V3::new(4.0, 24.0, 2.0),
+            tx: 16.0,
+            ty: 16.0,
+            w: 8.0,
+            h: 12.0,
+            d: 4.0,
+        },
+        // Right Arm
+        BodyPartDef {
+            min: V3::new(-8.0, 12.0, -2.0),
+            max: V3::new(-4.0, 24.0, 2.0),
+            tx: 40.0,
+            ty: 16.0,
+            w: 4.0,
+            h: 12.0,
+            d: 4.0,
+        },
+        // Left Arm
+        BodyPartDef {
+            min: V3::new(4.0, 12.0, -2.0),
+            max: V3::new(8.0, 24.0, 2.0),
+            tx: 32.0,
+            ty: 48.0,
+            w: 4.0,
+            h: 12.0,
+            d: 4.0,
+        },
+        // Right Leg
+        BodyPartDef {
+            min: V3::new(-4.0, 0.0, -2.0),
+            max: V3::new(0.0, 12.0, 2.0),
+            tx: 0.0,
+            ty: 16.0,
+            w: 4.0,
+            h: 12.0,
+            d: 4.0,
+        },
+        // Left Leg
+        BodyPartDef {
+            min: V3::new(0.0, 0.0, -2.0),
+            max: V3::new(4.0, 12.0, 2.0),
+            tx: 16.0,
+            ty: 48.0,
+            w: 4.0,
+            h: 12.0,
+            d: 4.0,
+        },
+        // ── Overlay layers (slightly expanded boxes) ──
+        // Head overlay (hat)
+        BodyPartDef {
+            min: V3::new(-4.0 - e, 24.0 - e, -4.0 - e),
+            max: V3::new(4.0 + e, 32.0 + e, 4.0 + e),
+            tx: 32.0,
+            ty: 0.0,
+            w: 8.0,
+            h: 8.0,
+            d: 8.0,
+        },
+        // Body overlay
+        BodyPartDef {
+            min: V3::new(-4.0 - e, 12.0 - e, -2.0 - e),
+            max: V3::new(4.0 + e, 24.0 + e, 2.0 + e),
+            tx: 16.0,
+            ty: 32.0,
+            w: 8.0,
+            h: 12.0,
+            d: 4.0,
+        },
+        // Right Arm overlay
+        BodyPartDef {
+            min: V3::new(-8.0 - e, 12.0 - e, -2.0 - e),
+            max: V3::new(-4.0 + e, 24.0 + e, 2.0 + e),
+            tx: 40.0,
+            ty: 32.0,
+            w: 4.0,
+            h: 12.0,
+            d: 4.0,
+        },
+        // Left Arm overlay
+        BodyPartDef {
+            min: V3::new(4.0 - e, 12.0 - e, -2.0 - e),
+            max: V3::new(8.0 + e, 24.0 + e, 2.0 + e),
+            tx: 48.0,
+            ty: 48.0,
+            w: 4.0,
+            h: 12.0,
+            d: 4.0,
+        },
+        // Right Leg overlay
+        BodyPartDef {
+            min: V3::new(-4.0 - e, 0.0 - e, -2.0 - e),
+            max: V3::new(0.0 + e, 12.0 + e, 2.0 + e),
+            tx: 0.0,
+            ty: 32.0,
+            w: 4.0,
+            h: 12.0,
+            d: 4.0,
+        },
+        // Left Leg overlay
+        BodyPartDef {
+            min: V3::new(0.0 - e, 0.0 - e, -2.0 - e),
+            max: V3::new(4.0 + e, 12.0 + e, 2.0 + e),
+            tx: 0.0,
+            ty: 48.0,
+            w: 4.0,
+            h: 12.0,
+            d: 4.0,
+        },
+    ]
+}
+
+// ── Rasterization ───────────────────────────────────────────────────────────
+
+/// 2D edge function: positive when `p` is to the left of edge `a→b`.
+#[inline]
+fn edge(ax: f64, ay: f64, bx: f64, by: f64, px: f64, py: f64) -> f64 {
+    (bx - ax) * (py - ay) - (by - ay) * (px - ax)
+}
+
+/// Alpha-blend `src` over `dst` (premultiplied-style, simple).
+#[inline]
+fn alpha_blend(dst: &mut Rgba<u8>, src: Rgba<u8>) {
+    let sa = src[3] as u16;
+    if sa == 0 {
+        return;
+    }
+    if sa == 255 {
+        *dst = src;
+        return;
+    }
+    let da = dst[3] as u16;
+    let inv_sa = 255 - sa;
+    let out_a = sa + (da * inv_sa) / 255;
+    if out_a == 0 {
+        return;
+    }
+    for i in 0..3 {
+        dst[i] = ((src[i] as u16 * sa + dst[i] as u16 * da * inv_sa / 255) / out_a) as u8;
+    }
+    dst[3] = out_a as u8;
+}
+
+/// Rasterize a single triangle with texture mapping and z-buffering.
+fn rasterize_triangle(
+    // Screen-space vertices (x, y, z for depth)
+    v0: (f64, f64, f64),
+    v1: (f64, f64, f64),
+    v2: (f64, f64, f64),
+    // Texture coordinates (absolute pixel coords in skin)
+    uv0: (f64, f64),
+    uv1: (f64, f64),
+    uv2: (f64, f64),
+    skin: &image::DynamicImage,
+    output: &mut RgbaImage,
+    zbuf: &mut [f64],
+    out_w: u32,
+    out_h: u32,
+) {
+    let skin_w = skin.width();
+    let skin_h = skin.height();
+
+    // Bounding box (clamped to output)
+    let min_x = v0.0.min(v1.0).min(v2.0).floor().max(0.0) as i32;
+    let max_x = v0.0.max(v1.0).max(v2.0).ceil().min(out_w as f64 - 1.0) as i32;
+    let min_y = v0.1.min(v1.1).min(v2.1).floor().max(0.0) as i32;
+    let max_y = v0.1.max(v1.1).max(v2.1).ceil().min(out_h as f64 - 1.0) as i32;
+
+    let area = edge(v0.0, v0.1, v1.0, v1.1, v2.0, v2.1);
+    if area.abs() < 0.001 {
+        return; // degenerate
+    }
+    let inv_area = 1.0 / area;
+
+    for py in min_y..=max_y {
+        for px in min_x..=max_x {
+            let cx = px as f64 + 0.5;
+            let cy = py as f64 + 0.5;
+
+            let w0 = edge(v1.0, v1.1, v2.0, v2.1, cx, cy) * inv_area;
+            let w1 = edge(v2.0, v2.1, v0.0, v0.1, cx, cy) * inv_area;
+            let w2 = 1.0 - w0 - w1;
+
+            if w0 >= 0.0 && w1 >= 0.0 && w2 >= 0.0 {
+                let z = w0 * v0.2 + w1 * v1.2 + w2 * v2.2;
+                let idx = (py as u32 * out_w + px as u32) as usize;
+
+                if z > zbuf[idx] {
+                    let u = w0 * uv0.0 + w1 * uv1.0 + w2 * uv2.0;
+                    let v = w0 * uv0.1 + w1 * uv1.1 + w2 * uv2.1;
+
+                    // Nearest-neighbor sampling (crisp Minecraft pixels)
+                    let tx = (u.floor() as u32).min(skin_w - 1);
+                    let ty = (v.floor() as u32).min(skin_h - 1);
+                    let pixel = skin.get_pixel(tx, ty);
+
+                    if pixel[3] > 0 {
+                        zbuf[idx] = z;
+                        let dst = output.get_pixel_mut(px as u32, py as u32);
+                        alpha_blend(dst, pixel);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Rasterize a quad (4 vertices) as two triangles.
+fn rasterize_quad(
+    verts: &[(f64, f64, f64); 4],
+    uvs: &[(f64, f64); 4],
+    skin: &image::DynamicImage,
+    output: &mut RgbaImage,
+    zbuf: &mut [f64],
+    out_w: u32,
+    out_h: u32,
+) {
+    // Triangle 1: v0, v1, v2
+    rasterize_triangle(verts[0], verts[1], verts[2], uvs[0], uvs[1], uvs[2], skin, output, zbuf, out_w, out_h);
+    // Triangle 2: v0, v2, v3
+    rasterize_triangle(verts[0], verts[2], verts[3], uvs[0], uvs[2], uvs[3], skin, output, zbuf, out_w, out_h);
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/// Render a Minecraft skin into an isometric 3D view, returning raw RGBA pixel data.
+///
+/// - `skin_png_bytes`: the full 64×64 (or 64×32 legacy) skin texture as PNG.
+/// - `out_width`, `out_height`: desired output image dimensions.
+/// - `yaw_deg`: Y-axis rotation in degrees (horizontal spin).
+/// - `pitch_deg`: X-axis rotation in degrees (vertical tilt; negative = looking from above).
+///
+/// Returns the rendered `RgbaImage`, or `None` on failure.
+pub fn render_skin_3d_raw(
+    skin_png_bytes: &[u8],
+    out_width: u32,
+    out_height: u32,
+    yaw_deg: f64,
+    pitch_deg: f64,
+) -> Option<RgbaImage> {
+    let skin = image::load_from_memory_with_format(skin_png_bytes, ImageFormat::Png).ok()?;
+
+    // Handle legacy 64×32 skins by only using the top portion body parts
+    let is_legacy = skin.height() < 64;
+
+    let rot = Mat3::rotation_yx(yaw_deg.to_radians(), pitch_deg.to_radians());
+
+    // Center of model vertically (player is 32 units tall, from y=0 to y=32)
+    let center_y = 16.0;
+
+    // Gather all quads from all body parts
+    let parts = player_model();
+    let mut projected_quads: Vec<([(f64, f64, f64); 4], [(f64, f64); 4], f64)> = Vec::new();
+
+    for (i, part) in parts.iter().enumerate() {
+        // Skip overlay left limbs on legacy skins (they don't exist in 64×32)
+        if is_legacy && i >= 6 {
+            // Overlay layers: indices 6..12
+            // For legacy skins, only head overlay (index 6) works (at 32,0)
+            // Skip body/arm/leg overlays that reference rows >= 32
+            if i > 6 {
+                continue;
+            }
+        }
+        // Skip left limb base layers on legacy skins (use right limb mirrored – but for
+        // simplicity we just skip; they'd sample garbage from the texture)
+        if is_legacy && (i == 3 || i == 5) {
+            continue;
+        }
+
+        let quads = box_quads(part.min, part.max, part.tx, part.ty, part.w, part.h, part.d);
+
+        for quad in &quads {
+            // Rotate normal to check visibility
+            let rn = rot.transform(quad.normal);
+            // Camera looks along -Z, so faces with normal.z > 0 face the camera
+            if rn.z <= 0.0 {
+                continue;
+            }
+
+            // Transform vertices
+            let mut screen_verts = [(0.0, 0.0, 0.0); 4];
+            let mut avg_z = 0.0;
+            for (j, v) in quad.verts.iter().enumerate() {
+                let centered = V3::new(v.x, v.y - center_y, v.z);
+                let rv = rot.transform(centered);
+                screen_verts[j] = (rv.x, -rv.y, rv.z); // flip Y for screen coords (Y down)
+                avg_z += rv.z;
+            }
+            avg_z /= 4.0;
+
+            projected_quads.push((screen_verts, quad.uvs, avg_z));
+        }
+    }
+
+    // Sort back-to-front (painter's algorithm): smaller Z = further from camera = draw first
+    projected_quads.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap_or(std::cmp::Ordering::Equal));
+
+    // Compute bounding box of all projected vertices to determine scale + offset
+    let mut min_x = f64::MAX;
+    let mut max_x = f64::MIN;
+    let mut min_y = f64::MAX;
+    let mut max_y = f64::MIN;
+    for (verts, _, _) in &projected_quads {
+        for &(x, y, _) in verts {
+            min_x = min_x.min(x);
+            max_x = max_x.max(x);
+            min_y = min_y.min(y);
+            max_y = max_y.max(y);
+        }
+    }
+
+    if max_x <= min_x || max_y <= min_y {
+        return None;
+    }
+
+    let model_w = max_x - min_x;
+    let model_h = max_y - min_y;
+    let padding = 4.0; // pixels of padding on each side
+    let avail_w = out_width as f64 - 2.0 * padding;
+    let avail_h = out_height as f64 - 2.0 * padding;
+    let scale = (avail_w / model_w).min(avail_h / model_h);
+    let offset_x = padding + (avail_w - model_w * scale) / 2.0 - min_x * scale;
+    let offset_y = padding + (avail_h - model_h * scale) / 2.0 - min_y * scale;
+
+    // Create output image (transparent background)
+    let mut output = RgbaImage::new(out_width, out_height);
+    let mut zbuf = vec![f64::MIN; (out_width * out_height) as usize];
+
+    // Rasterize each quad
+    for (verts, uvs, _) in &projected_quads {
+        let mut sv = [(0.0, 0.0, 0.0); 4];
+        for i in 0..4 {
+            sv[i] = (verts[i].0 * scale + offset_x, verts[i].1 * scale + offset_y, verts[i].2);
+        }
+        rasterize_quad(&sv, uvs, &skin, &mut output, &mut zbuf, out_width, out_height);
+    }
+
+    Some(output)
+}
+
+/// Render a Minecraft skin into an isometric 3D view, returning PNG-encoded bytes.
+///
+/// Convenience wrapper around [`render_skin_3d_raw`] that encodes the result to PNG.
+pub fn render_skin_3d(
+    skin_png_bytes: &[u8],
+    out_width: u32,
+    out_height: u32,
+    yaw_deg: f64,
+    pitch_deg: f64,
+) -> Option<Vec<u8>> {
+    let output = render_skin_3d_raw(skin_png_bytes, out_width, out_height, yaw_deg, pitch_deg)?;
+    let mut png_bytes = Vec::new();
+    output.write_to(&mut Cursor::new(&mut png_bytes), ImageFormat::Png).ok()?;
+    Some(png_bytes)
+}

--- a/crates/frontend/src/ui.rs
+++ b/crates/frontend/src/ui.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 use crate::{
     component::{menu::{MenuGroup, MenuGroupItem}, page_path::PagePath}, entity::{
         DataEntities, instance::{InstanceAddedEvent, InstanceEntries, InstanceModifiedEvent, InstanceMovedToTopEvent, InstanceRemovedEvent}
-    }, icon::PandoraIcon, interface_config::InterfaceConfig, modals, pages::{import::ImportPage, instance::instance_page::{InstancePage, InstanceSubpageType}, instances_page::InstancesPage, modrinth_page::ModrinthSearchPage, syncing_page::SyncingPage}, png_render_cache, ts
+    }, icon::PandoraIcon, interface_config::InterfaceConfig, modals, pages::{import::ImportPage, instance::instance_page::{InstancePage, InstanceSubpageType}, instances_page::InstancesPage, modrinth_page::ModrinthSearchPage, profile_page::ProfilePage, syncing_page::SyncingPage}, png_render_cache, ts
 };
 
 pub struct LauncherUI {
@@ -37,6 +37,7 @@ pub enum PageType {
     },
     Import,
     Syncing,
+    Profile,
     InstancePage(InstanceID, InstanceSubpageType),
 }
 
@@ -54,6 +55,7 @@ impl PageType {
             },
             PageType::Import => SerializedPageType::Import,
             PageType::Syncing => SerializedPageType::Syncing,
+            PageType::Profile => SerializedPageType::Profile,
             PageType::InstancePage(id, _) => {
                 if let Some(name) = InstanceEntries::find_name_by_id(&data.instances, *id, cx) {
                     SerializedPageType::InstancePage(name)
@@ -77,6 +79,7 @@ impl PageType {
             },
             SerializedPageType::Import => PageType::Import,
             SerializedPageType::Syncing => PageType::Syncing,
+            SerializedPageType::Profile => PageType::Profile,
             SerializedPageType::InstancePage(name) => {
                 if let Some(id) = InstanceEntries::find_id_by_name(&data.instances, name, cx) {
                     PageType::InstancePage(id, InstanceSubpageType::Quickplay)
@@ -98,6 +101,7 @@ pub enum SerializedPageType {
     },
     Import,
     Syncing,
+    Profile,
     InstancePage(SharedString),
 }
 
@@ -110,6 +114,7 @@ pub enum LauncherPage {
     },
     Import(Entity<ImportPage>),
     Syncing(Entity<SyncingPage>),
+    Profile(Entity<ProfilePage>),
     InstancePage(InstanceID, InstanceSubpageType, Entity<InstancePage>),
 }
 
@@ -120,6 +125,7 @@ impl LauncherPage {
             LauncherPage::Modrinth { page, .. } => page.into_any_element(),
             LauncherPage::Import(entity) => entity.into_any_element(),
             LauncherPage::Syncing(entity) => entity.into_any_element(),
+            LauncherPage::Profile(entity) => entity.into_any_element(),
             LauncherPage::InstancePage(_, _, entity) => entity.into_any_element(),
         }
     }
@@ -130,6 +136,7 @@ impl LauncherPage {
             LauncherPage::Modrinth { installing_for, .. } => PageType::Modrinth { installing_for: *installing_for, project_type: None },
             LauncherPage::Import(_) => PageType::Import,
             LauncherPage::Syncing(_) => PageType::Syncing,
+            LauncherPage::Profile(_) => PageType::Profile,
             LauncherPage::InstancePage(id, subpage, _) => PageType::InstancePage(*id, *subpage),
         }
     }
@@ -238,6 +245,9 @@ impl LauncherUI {
             PageType::Syncing => {
                 LauncherPage::Syncing(cx.new(|cx| SyncingPage::new(data, window, cx)))
             },
+            PageType::Profile => {
+                LauncherPage::Profile(cx.new(|cx| ProfilePage::new(data, window, cx)))
+            },
             PageType::InstancePage(id, subpage) => {
                 LauncherPage::InstancePage(id, subpage, cx.new(|cx| {
                     InstancePage::new(id, subpage, path, data, window, cx)
@@ -292,11 +302,19 @@ impl Render for LauncherUI {
                     launcher.switch_page(PageType::Syncing, &[], window, cx);
                 })));
 
-        let mut groups: heapless::Vec<MenuGroup, 4> = heapless::Vec::new();
+        let account_group = MenuGroup::new(ts!("profile.title"))
+            .child(MenuGroupItem::new(ts!("profile.sidebar"))
+                .active(page_type == PageType::Profile)
+                .on_click(cx.listener(|launcher, _, window, cx| {
+                    launcher.switch_page(PageType::Profile, &[], window, cx);
+                })));
+
+        let mut groups: heapless::Vec<MenuGroup, 5> = heapless::Vec::new();
 
         let _ = groups.push(library_group);
         let _ = groups.push(content_group);
         let _ = groups.push(files_group);
+        let _ = groups.push(account_group);
 
         if !self.recent_instances.is_empty() {
             let mut recent_instances_group = MenuGroup::new(ts!("instance.recent"));


### PR DESCRIPTION
- Software 3D rasterizer for Minecraft player skins with drag-to-rotate
- Skin history tracking with persistent storage
- Apply/revert skins via Mojang API
- Support for both Classic and Slim skin models

<img width="1537" height="900" alt="Screenshot 2026-03-03 at 5 47 53 AM" src="https://github.com/user-attachments/assets/13ec4fbf-83cf-415d-b45d-4bb4151ee37f" />
