### PR TITLE
fixed crash when importing vanilla atlauncher instances

### DIFF
--- a/crates/backend/src/launcher_import/atlauncher.rs
+++ b/crates/backend/src/launcher_import/atlauncher.rs
@@ -248,13 +248,10 @@ struct AtLauncherDisplayClaim {
 
 
 pub async fn import_from_atlauncher(backend: &BackendState, path: &Path, import_accounts: bool, import_instance: bool, modal_action: ModalAction) {
-	// probably a better way of doing this mess...
-	let launcher_config = {
-		match std::fs::read(path.join("configs/ATLauncher.json")).ok() {
-		    Some(launcher_config_bytes) => serde_json::from_slice::<AtLauncherConfig>(&launcher_config_bytes).expect("Failed to parse to json"),
-		    None => return,
-		}
-	};
+    let Ok(launcher_config_bytes) = std::fs::read(path.join("configs/ATLauncher.json")) else {
+        return;
+    };
+	let launcher_config = serde_json::from_slice::<AtLauncherConfig>(&launcher_config_bytes).expect("Failed to parse to json");
 	// log::debug!("Launcher config: {}", launcher_config.is_some());
 
 	if import_accounts {
@@ -467,6 +464,38 @@ fn import_instances_from_atlauncher(backend: &BackendState, path: &Path, launche
 		// remove old configuration, rename icon path.
 		_ = std::fs::rename(&target_dot_minecraft.join("instance.png"), &to_import.pandora_path.join("icon.png"));
 		_ = std::fs::remove_file(&target_dot_minecraft.join("instance.json"));
+
+        // move disable mods
+        let mods_path = target_dot_minecraft.join("mods");
+        let resourcepacks_path = target_dot_minecraft.join("resourcepacks");
+
+        let disabled_mods_path = target_dot_minecraft.join("disabledmods");
+        if let Ok(disabled_mods_folder) =  std::fs::read_dir(&disabled_mods_path){
+            // moving mods to the mods folder could throw an error if there was no mod folder, if all mods were disabled for example
+            _ = std::fs::create_dir(&mods_path);
+            _ = std::fs::create_dir(&resourcepacks_path);
+
+            for mod_file in disabled_mods_folder{
+                let Ok(entry) = mod_file else{
+                    continue;
+                };
+
+                let Ok(file_name) = entry.file_name().to_owned().into_string() else {
+                    continue;
+                };
+
+                let new_path = match &file_name {
+                    resourcepack if resourcepack.ends_with(".zip") => &resourcepacks_path,
+                    jar_mod if jar_mod.ends_with(".jar") => &mods_path,
+                    _=> continue
+                };
+
+                _ = std::fs::rename(entry.path(),  new_path.join( file_name + ".disabled"));
+            }
+
+            // cleanup old disabled mod folder
+            _ = std::fs::remove_dir_all(&disabled_mods_path);
+        }
 
 		let info_path = to_import.pandora_path.join("info_v1.json");
 		_ = write_safe(&info_path, &configuration_bytes);


### PR DESCRIPTION
So I wanted to test atlauncher importing and I noticed a small issue when parsing atlaucher's `instance.json` files, `loader_version` field may not appear if the instance is using vanilla loader so I put an `Option` and made sure it went vanilla when no `loader_version` was supplied.

also I noticed some of the indentation looked weird on my editor so I tried running `cargo fmt` and it did a lot of stuff on a lot of files, but I'm a big scared to push such a big commit, could you try it yourself and let me know if I'm the only one getting wrong formating.