### PR TITLE
Add "Hide Server Addresses" Privacy Setting

### DIFF
--- a/crates/frontend/locales/locales.yml
+++ b/crates/frontend/locales/locales.yml
@@ -715,6 +715,11 @@ settings:
       en: Hide main window on launch
     open_game_output:
       en: Open game output on launch
+  privacy:
+    title:
+      en: Privacy
+    hide_server_addresses:
+      en: Hide server addresses
   proxy:
     title:
       en: Proxy Settings

--- a/crates/frontend/src/interface_config.rs
+++ b/crates/frontend/src/interface_config.rs
@@ -40,6 +40,8 @@ pub struct InterfaceConfig {
     #[serde(default, deserialize_with = "schema::try_deserialize")]
     pub hide_main_window_on_launch: bool,
     #[serde(default, deserialize_with = "schema::try_deserialize")]
+    pub hide_server_addresses: bool,
+    #[serde(default, deserialize_with = "schema::try_deserialize")]
     pub show_snapshots_in_create_instance: bool,
     #[serde(default, deserialize_with = "schema::try_deserialize")]
     pub instances_view_mode: InstancesViewMode,

--- a/crates/frontend/src/modals/settings.rs
+++ b/crates/frontend/src/modals/settings.rs
@@ -312,6 +312,17 @@ impl Settings {
             div = div.child(Spinner::new().large());
         }
 
+        div = div.child(crate::labelled(ts!("settings.privacy.title"),
+            v_flex().gap_2()
+                .child(Checkbox::new("hide-server-addresses")
+                    .label(ts!("settings.privacy.hide_server_addresses"))
+                    .checked(interface_config.hide_server_addresses)
+                    .on_click(|value, _, cx| {
+                        InterfaceConfig::get_mut(cx).hide_server_addresses = *value;
+                    }))
+                )
+        );
+
         div
     }
 

--- a/crates/frontend/src/pages/instance/quickplay_subpage.rs
+++ b/crates/frontend/src/pages/instance/quickplay_subpage.rs
@@ -17,7 +17,7 @@ use gpui_component::{
     v_flex,
 };
 
-use crate::{entity::instance::InstanceEntry, icon::PandoraIcon, png_render_cache, root, ts};
+use crate::{entity::instance::InstanceEntry, icon::PandoraIcon, interface_config::InterfaceConfig, png_render_cache, root, ts};
 
 pub struct InstanceQuickplaySubpage {
     instance: InstanceID,
@@ -236,6 +236,10 @@ impl ListDelegate for ServersListDelegate {
     }
 
     fn render_item(&mut self, ix: IndexPath, _window: &mut Window, cx: &mut Context<ListState<Self>>) -> Option<Self::Item> {
+        let interface_config = InterfaceConfig::get(cx);
+
+        let interface_config_hide_server_addresses = interface_config.hide_server_addresses;
+
         let summary = self.searched.get(ix.row)?;
 
         let icon = if let Some(png_icon) = summary.png_icon.as_ref() {
@@ -246,7 +250,9 @@ impl ListDelegate for ServersListDelegate {
 
         let description = v_flex()
             .child(SharedString::from(summary.name.clone()))
-            .child(div().text_color(cx.theme().muted_foreground).child(SharedString::from(summary.ip.clone())));
+            .when(!interface_config_hide_server_addresses, |parent| {
+                parent.child(div().text_color(cx.theme().muted_foreground).child(SharedString::from(summary.ip.clone())))
+            });
 
         let id = self.id;
         let name = self.name.clone();


### PR DESCRIPTION
This PR adds a privacy section to the interface config with a "hide server addresses" config.

This is helpful for those streaming or sharing screen while showing the launcher. 

Image:
<img width="1911" height="1042" alt="image" src="https://github.com/user-attachments/assets/d5320d5c-f63a-4511-867f-6ebe5ca1c799" />


Please let me know if you would like the setting inverted, somewhere else, or not present entirely.