### PR TITLE
Add Quilt loader support and fix compilation errors

### DIFF
--- a/crates/backend/src/backend_handler.rs
+++ b/crates/backend/src/backend_handler.rs
@@ -14,7 +14,7 @@ use ustr::Ustr;
 use uuid::Uuid;
 
 use crate::{
-    BackendState, CachedMinecraftProfile, LoginError, account::BackendAccount, arcfactory::ArcStrFactory, instance::ContentFolder, launch::{ArgumentExpansionKey, LaunchError}, log_reader, metadata::{items::{AssetsIndexMetadataItem, CurseforgeGetModFilesMetadataItem, CurseforgeSearchMetadataItem, FabricLoaderManifestMetadataItem, ForgeInstallerMavenMetadataItem, MinecraftVersionManifestMetadataItem, MinecraftVersionMetadataItem, ModrinthProjectMetadataItem, ModrinthProjectVersionsMetadataItem, ModrinthSearchMetadataItem, ModrinthV3VersionUpdateMetadataItem, ModrinthVersionUpdateMetadataItem, MojangJavaRuntimeComponentMetadataItem, MojangJavaRuntimesMetadataItem, NeoforgeInstallerMavenMetadataItem, VersionUpdateParameters, VersionV3LoaderFields, VersionV3UpdateParameters}, manager::MetaLoadError}, mod_metadata::{ContentUpdateAction, ContentUpdateKey}, skin_manager::SkinManager
+    BackendState, CachedMinecraftProfile, LoginError, account::BackendAccount, arcfactory::ArcStrFactory, instance::ContentFolder, launch::{ArgumentExpansionKey, LaunchError}, log_reader, metadata::{items::{AssetsIndexMetadataItem, CurseforgeGetModFilesMetadataItem, CurseforgeSearchMetadataItem, FabricLoaderManifestMetadataItem, ForgeInstallerMavenMetadataItem, MinecraftVersionManifestMetadataItem, MinecraftVersionMetadataItem, ModrinthProjectMetadataItem, ModrinthProjectVersionsMetadataItem, ModrinthSearchMetadataItem, ModrinthV3VersionUpdateMetadataItem, ModrinthVersionUpdateMetadataItem, MojangJavaRuntimeComponentMetadataItem, MojangJavaRuntimesMetadataItem, NeoforgeInstallerMavenMetadataItem, QuiltLoaderManifestMetadataItem, VersionUpdateParameters, VersionV3LoaderFields, VersionV3UpdateParameters}, manager::MetaLoadError}, mod_metadata::{ContentUpdateAction, ContentUpdateKey}, skin_manager::SkinManager
 };
 
 impl BackendState {
@@ -32,6 +32,10 @@ impl BackendState {
                         bridge::meta::MetadataRequest::FabricLoaderManifest => {
                             let (result, handle) = meta.fetch_with_keepalive(&FabricLoaderManifestMetadataItem, force_reload).await;
                             (result.map(MetadataResult::FabricLoaderManifest), handle)
+                        },
+                        bridge::meta::MetadataRequest::QuiltLoaderManifest => {
+                            let (result, handle) = meta.fetch_with_keepalive(&QuiltLoaderManifestMetadataItem, force_reload).await;
+                            (result.map(MetadataResult::QuiltLoaderManifest), handle)
                         },
                         bridge::meta::MetadataRequest::ForgeMavenManifest => {
                             let (result, handle) = meta.fetch_with_keepalive(&ForgeInstallerMavenMetadataItem, force_reload).await;

--- a/crates/backend/src/install_content.rs
+++ b/crates/backend/src/install_content.rs
@@ -484,6 +484,7 @@ impl BackendState {
                     Loader::Fabric => Some(CurseforgeModLoaderType::Fabric as u32),
                     Loader::Forge => Some(CurseforgeModLoaderType::Forge as u32),
                     Loader::NeoForge => Some(CurseforgeModLoaderType::NeoForge as u32),
+                    Loader::Quilt => Some(CurseforgeModLoaderType::Quilt as u32),
                     Loader::Unknown => None,
                 };
 

--- a/crates/backend/src/launch.rs
+++ b/crates/backend/src/launch.rs
@@ -433,6 +433,134 @@ impl Launcher {
                     true
                 ).await
             },
+            Loader::Quilt => {
+                // Quilt uses the same launch mechanism as Fabric
+                let versions = self.meta.fetch(&MinecraftVersionManifestMetadataItem).map_err(LaunchError::from);
+
+                let quilt_loader_version = async move {
+                    if let Some(preferred_version) = instance_info.preferred_loader_version {
+                        Ok(preferred_version)
+                    } else {
+                        let manifest = self.meta.fetch(&crate::metadata::items::QuiltLoaderManifestMetadataItem).map_err(LaunchError::from).await?;
+
+                        let mut latest_loader_version = manifest.0.iter().find(|v| !v.version.contains("beta"));
+                        if latest_loader_version.is_none() {
+                            latest_loader_version = manifest.0.first();
+                        }
+                        Ok(latest_loader_version.unwrap().version)
+                    }
+                };
+
+                launch_tracker.add_total(4);
+                launch_tracker.notify();
+
+                let launch_tracker2 = launch_tracker.clone();
+                let meta2 = Arc::clone(&self.meta);
+                let minecraft_version = instance_info.minecraft_version;
+                let quilt_launch = quilt_loader_version.and_then(async move |loader_version| {
+                    launch_tracker2.add_count(1);
+                    launch_tracker2.notify();
+
+                    let value = meta2.fetch(&crate::metadata::items::QuiltLaunchMetadataItem {
+                        minecraft_version,
+                        loader_version,
+                    }).await?;
+
+                    launch_tracker2.add_count(1);
+                    launch_tracker2.notify();
+
+                    Ok(value)
+                });
+
+                let launch_tracker3 = launch_tracker.clone();
+                let meta3 = Arc::clone(&self.meta);
+                let instance_version = instance_info.minecraft_version;
+                let version = versions.and_then(async move |versions| {
+                    launch_tracker3.add_count(1);
+                    launch_tracker3.notify();
+
+                    let Some(version) = versions.versions.iter().find(|v| v.id == instance_version) else {
+                        return Err(LaunchError::CantFindVersion(instance_version.as_str()));
+                    };
+
+                    let value = meta3.fetch(&MinecraftVersionMetadataItem(version)).await?;
+
+                    launch_tracker3.add_count(1);
+                    launch_tracker3.notify();
+
+                    Ok(value)
+                });
+
+                let (version, quilt_launch): (Arc<MinecraftVersion>, Arc<FabricLaunch>) =
+                    futures::future::try_join(version, quilt_launch).await?;
+
+                let mut version: MinecraftVersion = (*version).clone();
+
+                if let Some(loader) = &quilt_launch.loader {
+                    let loader_coordinate = MavenCoordinate::create(&loader.maven);
+                    let artifact_path = loader_coordinate.artifact_path();
+                    version.libraries.push(GameLibrary {
+                        downloads: GameLibraryDownloads {
+                            artifact: Some(GameLibraryArtifact {
+                                url: format!("https://maven.quiltmc.org/repository/release/{}", &artifact_path).into(),
+                                path: artifact_path.into(),
+                                sha1: None,
+                                size: None,
+                            }),
+                            classifiers: None,
+                        },
+                        name: loader.maven,
+                        rules: None,
+                        natives: None,
+                        extract: None,
+                    });
+                }
+
+                if let Some(intermediary) = &quilt_launch.intermediary {
+                    let intermediary_coordinate = MavenCoordinate::create(&intermediary.maven);
+                    let artifact_path = intermediary_coordinate.artifact_path();
+                    version.libraries.push(GameLibrary {
+                        downloads: GameLibraryDownloads {
+                            artifact: Some(GameLibraryArtifact {
+                                url: format!("https://maven.quiltmc.org/repository/release/{}", &artifact_path).into(),
+                                path: artifact_path.into(),
+                                sha1: None,
+                                size: None,
+                            }),
+                            classifiers: None,
+                        },
+                        name: intermediary.maven,
+                        rules: None,
+                        natives: None,
+                        extract: None,
+                    });
+                }
+
+                let libraries = &quilt_launch.launcher_meta.libraries;
+                for library in libraries.common.iter().chain(libraries.client.iter()) {
+                    let library_coordinate = MavenCoordinate::create(&library.name);
+                    let artifact_path = library_coordinate.artifact_path();
+                    version.libraries.push(GameLibrary {
+                        downloads: GameLibraryDownloads {
+                            artifact: Some(GameLibraryArtifact {
+                                url: format!("{}{}", &library.url, &artifact_path).into(),
+                                path: artifact_path.into(),
+                                sha1: Some(library.sha1),
+                                size: Some(library.size),
+                            }),
+                            classifiers: None,
+                        },
+                        name: library.name,
+                        rules: None,
+                        natives: None,
+                        extract: None,
+                    });
+                }
+
+                version.main_class = quilt_launch.launcher_meta.main_class.client;
+
+                Ok((Arc::new(version), AddVanillaJar::Yes))
+            },
             Loader::Unknown => todo!(),
         }
     }

--- a/crates/backend/src/metadata/items.rs
+++ b/crates/backend/src/metadata/items.rs
@@ -4,7 +4,7 @@ use std::{
 
 use reqwest::RequestBuilder;
 use schema::{
-    assets_index::AssetsIndex, curseforge::{CURSEFORGE_SEARCH_URL, CurseforgeGetModFilesRequest, CurseforgeGetModFilesResult, CurseforgeSearchRequest, CurseforgeSearchResult, MINECRAFT_GAME_ID}, fabric_launch::FabricLaunch, fabric_loader_manifest::{FABRIC_LOADER_MANIFEST_URL, FabricLoaderManifest}, forge::{ForgeMavenManifest, NeoforgeMavenManifest, VersionFragment}, java_runtime_component::JavaRuntimeComponentManifest, java_runtimes::{JAVA_RUNTIMES_URL, JavaRuntimes}, maven::MavenMetadataXml, modrinth::{MODRINTH_PROJECT_URL, MODRINTH_SEARCH_URL, ModrinthLoader, ModrinthProjectRequest, ModrinthProjectResult, ModrinthProjectVersion, ModrinthProjectVersionsRequest, ModrinthProjectVersionsResult, ModrinthSearchRequest, ModrinthSearchResult, ModrinthVersionFileUpdateResult}, version::MinecraftVersion, version_manifest::{MOJANG_VERSION_MANIFEST_URL, MinecraftVersionLink, MinecraftVersionManifest}
+    assets_index::AssetsIndex, curseforge::{CURSEFORGE_SEARCH_URL, CurseforgeGetModFilesRequest, CurseforgeGetModFilesResult, CurseforgeSearchRequest, CurseforgeSearchResult, MINECRAFT_GAME_ID}, fabric_launch::FabricLaunch, fabric_loader_manifest::{FABRIC_LOADER_MANIFEST_URL, FabricLoaderManifest}, forge::{ForgeMavenManifest, NeoforgeMavenManifest, VersionFragment}, java_runtime_component::JavaRuntimeComponentManifest, java_runtimes::{JAVA_RUNTIMES_URL, JavaRuntimes}, maven::MavenMetadataXml, modrinth::{MODRINTH_PROJECT_URL, MODRINTH_SEARCH_URL, ModrinthLoader, ModrinthProjectRequest, ModrinthProjectResult, ModrinthProjectVersion, ModrinthProjectVersionsRequest, ModrinthProjectVersionsResult, ModrinthSearchRequest, ModrinthSearchResult, ModrinthVersionFileUpdateResult}, quilt_loader_manifest::{QUILT_LOADER_MANIFEST_URL, QuiltLoaderManifest}, version::MinecraftVersion, version_manifest::{MOJANG_VERSION_MANIFEST_URL, MinecraftVersionLink, MinecraftVersionManifest}
 };
 use serde::Serialize;
 use ustr::Ustr;
@@ -217,6 +217,33 @@ impl MetadataItem for FabricLoaderManifestMetadataItem {
 }
 
 #[derive(Debug)]
+pub struct QuiltLoaderManifestMetadataItem;
+
+impl MetadataItem for QuiltLoaderManifestMetadataItem {
+    type T = QuiltLoaderManifest;
+
+    fn request(&self, client: &reqwest::Client) -> RequestBuilder {
+        client.get(QUILT_LOADER_MANIFEST_URL)
+    }
+
+    fn expires(&self) -> bool {
+        true
+    }
+
+    fn cache_file(&self, metadata_manager: &MetadataManager) -> Option<impl AsRef<Path> + Send + Sync + 'static> {
+        Some(Arc::clone(&metadata_manager.quilt_loader_manifest_cache))
+    }
+
+    fn state(&self, states: &mut MetadataManagerStates) -> MetaLoadStateWrapper<Self::T> {
+        states.quilt_loader_manifest.clone()
+    }
+
+    fn deserialize(bytes: &[u8]) -> Result<Self::T, MetaLoadError> {
+        Ok(serde_json::from_slice(bytes)?)
+    }
+}
+
+#[derive(Debug)]
 pub struct FabricLaunchMetadataItem {
     pub minecraft_version: Ustr,
     pub loader_version: Ustr,
@@ -243,6 +270,40 @@ impl MetadataItem for FabricLaunchMetadataItem {
     fn state(&self, states: &mut MetadataManagerStates) -> MetaLoadStateWrapper<Self::T> {
         let key = (self.minecraft_version, self.loader_version);
         states.fabric_launch.entry(key).or_default().clone()
+    }
+
+    fn deserialize(bytes: &[u8]) -> Result<Self::T, MetaLoadError> {
+        Ok(serde_json::from_slice(bytes)?)
+    }
+}
+
+#[derive(Debug)]
+pub struct QuiltLaunchMetadataItem {
+    pub minecraft_version: Ustr,
+    pub loader_version: Ustr,
+}
+
+impl MetadataItem for QuiltLaunchMetadataItem {
+    type T = FabricLaunch;
+
+    fn request(&self, client: &reqwest::Client) -> RequestBuilder {
+        client.get(format!("https://meta.quiltmc.org/v3/versions/loader/{}/{}", self.minecraft_version, self.loader_version))
+    }
+
+    fn expires(&self) -> bool {
+        false
+    }
+
+    fn cache_file(&self, metadata_manager: &MetadataManager) -> Option<impl AsRef<Path> + Send + Sync + 'static> {
+        let mut path = metadata_manager.metadata_cache.join("quilt_launch");
+        path.push(self.minecraft_version.as_str());
+        path.push(self.loader_version.as_str());
+        Some(path)
+    }
+
+    fn state(&self, states: &mut MetadataManagerStates) -> MetaLoadStateWrapper<Self::T> {
+        let key = (self.minecraft_version, self.loader_version);
+        states.quilt_launch.entry(key).or_default().clone()
     }
 
     fn deserialize(bytes: &[u8]) -> Result<Self::T, MetaLoadError> {

--- a/crates/backend/src/metadata/manager.rs
+++ b/crates/backend/src/metadata/manager.rs
@@ -5,7 +5,7 @@ use std::{
 use bridge::keep_alive::{KeepAlive, KeepAliveHandle};
 use reqwest::StatusCode;
 use schema::{
-    assets_index::AssetsIndex, curseforge::{CurseforgeGetModFilesRequest, CurseforgeGetModFilesResult, CurseforgeSearchRequest, CurseforgeSearchResult}, fabric_launch::FabricLaunch, fabric_loader_manifest::FabricLoaderManifest, forge::{ForgeMavenManifest, NeoforgeMavenManifest}, java_runtime_component::JavaRuntimeComponentManifest, java_runtimes::JavaRuntimes, modrinth::{ModrinthProjectRequest, ModrinthProjectResult, ModrinthProjectVersion, ModrinthProjectVersionsRequest, ModrinthProjectVersionsResult, ModrinthSearchRequest, ModrinthSearchResult, ModrinthVersionFileUpdateResult}, version::MinecraftVersion, version_manifest::MinecraftVersionManifest
+    assets_index::AssetsIndex, curseforge::{CurseforgeGetModFilesRequest, CurseforgeGetModFilesResult, CurseforgeSearchRequest, CurseforgeSearchResult}, fabric_launch::FabricLaunch, fabric_loader_manifest::FabricLoaderManifest, forge::{ForgeMavenManifest, NeoforgeMavenManifest}, java_runtime_component::JavaRuntimeComponentManifest, java_runtimes::JavaRuntimes, modrinth::{ModrinthProjectRequest, ModrinthProjectResult, ModrinthProjectVersion, ModrinthProjectVersionsRequest, ModrinthProjectVersionsResult, ModrinthSearchRequest, ModrinthSearchResult, ModrinthVersionFileUpdateResult}, quilt_loader_manifest::QuiltLoaderManifest, version::MinecraftVersion, version_manifest::MinecraftVersionManifest
 };
 use serde::Deserialize;
 use sha1::{Digest, Sha1};
@@ -23,9 +23,11 @@ pub struct MetadataManagerStates {
     pub(super) minecraft_version_manifest: MetaLoadStateWrapper<MinecraftVersionManifest>,
     pub(super) mojang_java_runtimes: MetaLoadStateWrapper<JavaRuntimes>,
     pub(super) fabric_loader_manifest: MetaLoadStateWrapper<FabricLoaderManifest>,
+    pub(super) quilt_loader_manifest: MetaLoadStateWrapper<QuiltLoaderManifest>,
     pub(super) neoforge_installer_maven_manifest: MetaLoadStateWrapper<NeoforgeMavenManifest>,
     pub(super) forge_installer_maven_manifest: MetaLoadStateWrapper<ForgeMavenManifest>,
     pub(super) fabric_launch: HashMap<(Ustr, Ustr), MetaLoadStateWrapper<FabricLaunch>>,
+    pub(super) quilt_launch: HashMap<(Ustr, Ustr), MetaLoadStateWrapper<FabricLaunch>>,
     pub(super) version_info: HashMap<Ustr, MetaLoadStateWrapper<MinecraftVersion>>,
     pub(super) assets_index: HashMap<Ustr, MetaLoadStateWrapper<AssetsIndex>>,
     pub(super) java_runtime_manifests: HashMap<Ustr, MetaLoadStateWrapper<JavaRuntimeComponentManifest>>,
@@ -46,6 +48,7 @@ pub struct MetadataManager {
     pub(super) version_manifest_cache: Arc<Path>,
     pub(super) mojang_java_runtimes_cache: Arc<Path>,
     pub(super) fabric_loader_manifest_cache: Arc<Path>,
+    pub(super) quilt_loader_manifest_cache: Arc<Path>,
     pub(super) neoforge_installer_maven_cache: Arc<Path>,
     pub(super) forge_installer_maven_cache: Arc<Path>,
 
@@ -156,6 +159,7 @@ impl MetadataManager {
             version_manifest_cache: directory.join("version_manifest.json").into(),
             mojang_java_runtimes_cache: directory.join("mojang_java_runtimes.json").into(),
             fabric_loader_manifest_cache: directory.join("fabric_loader_manifest.json").into(),
+            quilt_loader_manifest_cache: directory.join("quilt_loader_manifest.json").into(),
             neoforge_installer_maven_cache: directory.join("neoforge_installer_maven.xml").into(),
             forge_installer_maven_cache: directory.join("forge_installer_maven.xml").into(),
             metadata_cache: directory,

--- a/crates/bridge/src/meta.rs
+++ b/crates/bridge/src/meta.rs
@@ -1,11 +1,12 @@
 use std::sync::Arc;
 
-use schema::{curseforge::{CurseforgeGetModFilesRequest, CurseforgeGetModFilesResult, CurseforgeSearchRequest, CurseforgeSearchResult}, fabric_loader_manifest::FabricLoaderManifest, forge::{ForgeMavenManifest, NeoforgeMavenManifest}, modrinth::{ModrinthProjectRequest, ModrinthProjectResult, ModrinthProjectVersionsRequest, ModrinthProjectVersionsResult, ModrinthSearchRequest, ModrinthSearchResult}, version_manifest::MinecraftVersionManifest};
+use schema::{curseforge::{CurseforgeGetModFilesRequest, CurseforgeGetModFilesResult, CurseforgeSearchRequest, CurseforgeSearchResult}, fabric_loader_manifest::FabricLoaderManifest, forge::{ForgeMavenManifest, NeoforgeMavenManifest}, modrinth::{ModrinthProjectRequest, ModrinthProjectResult, ModrinthProjectVersionsRequest, ModrinthProjectVersionsResult, ModrinthSearchRequest, ModrinthSearchResult}, quilt_loader_manifest::QuiltLoaderManifest, version_manifest::MinecraftVersionManifest};
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MetadataRequest {
     MinecraftVersionManifest,
     FabricLoaderManifest,
+    QuiltLoaderManifest,
     ForgeMavenManifest,
     NeoforgeMavenManifest,
     ModrinthSearch(ModrinthSearchRequest),
@@ -19,6 +20,7 @@ pub enum MetadataRequest {
 pub enum MetadataResult {
     MinecraftVersionManifest(Arc<MinecraftVersionManifest>),
     FabricLoaderManifest(Arc<FabricLoaderManifest>),
+    QuiltLoaderManifest(Arc<QuiltLoaderManifest>),
     ForgeMavenManifest(Arc<ForgeMavenManifest>),
     NeoforgeMavenManifest(Arc<NeoforgeMavenManifest>),
     ModrinthSearchResult(Arc<ModrinthSearchResult>),

--- a/crates/frontend/locales/locales.yml
+++ b/crates/frontend/locales/locales.yml
@@ -378,7 +378,7 @@ instance:
   loader:
     en: Loader
   loader_version:
-    en: "%{loader} Version"
+    en: "Loader Version"
   game_version:
     en: Game Version
   mc_version:
@@ -398,6 +398,8 @@ instance:
   versions_loading:
     game_versions:
       en: Loading Minecraft Versions...
+    loader_versions:
+      en: Loading Loader Versions...
     reload:
       en: Reload Versions
     possible_loader_error:

--- a/crates/frontend/src/entity/metadata.rs
+++ b/crates/frontend/src/entity/metadata.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use crate::ts;
 use bridge::{handle::BackendHandle, keep_alive::KeepAliveHandle, message::MessageToBackend, meta::{MetadataRequest, MetadataResult}};
 use gpui::{prelude::*, *};
-use schema::{curseforge::{CurseforgeGetModFilesResult, CurseforgeSearchResult}, fabric_loader_manifest::FabricLoaderManifest, forge::{ForgeMavenManifest, NeoforgeMavenManifest}, modrinth::{ModrinthProjectResult, ModrinthProjectVersionsResult, ModrinthSearchResult}, version_manifest::MinecraftVersionManifest};
+use schema::{curseforge::{CurseforgeGetModFilesResult, CurseforgeSearchResult}, fabric_loader_manifest::FabricLoaderManifest, forge::{ForgeMavenManifest, NeoforgeMavenManifest}, modrinth::{ModrinthProjectResult, ModrinthProjectVersionsResult, ModrinthSearchResult}, quilt_loader_manifest::QuiltLoaderManifest, version_manifest::MinecraftVersionManifest};
 
 #[derive(Debug)]
 pub enum FrontendMetadataState {
@@ -136,6 +136,7 @@ define_as_metadata_result!(MinecraftVersionManifest);
 define_as_metadata_result!(ModrinthSearchResult);
 define_as_metadata_result!(ModrinthProjectVersionsResult);
 define_as_metadata_result!(FabricLoaderManifest);
+define_as_metadata_result!(QuiltLoaderManifest);
 define_as_metadata_result!(ForgeMavenManifest);
 define_as_metadata_result!(NeoforgeMavenManifest);
 define_as_metadata_result!(ModrinthProjectResult);

--- a/crates/frontend/src/modals/create_instance.rs
+++ b/crates/frontend/src/modals/create_instance.rs
@@ -1,23 +1,72 @@
 use std::sync::Arc;
 
-use bridge::{handle::BackendHandle, message::{EmbeddedOrRaw, MessageToBackend}};
+use bridge::{handle::BackendHandle, message::{EmbeddedOrRaw, MessageToBackend}, meta::MetadataRequest};
 use gpui::{prelude::*, *};
 use gpui_component::{
-    ActiveTheme, Selectable, WindowExt, alert::Alert, button::{Button, ButtonGroup, ButtonVariants}, checkbox::Checkbox, dialog::Dialog, h_flex, input::{Input, InputEvent, InputState}, select::{Select, SelectState}, skeleton::Skeleton, v_flex
+    ActiveTheme, IndexPath, Selectable, WindowExt, alert::Alert, button::{Button, ButtonGroup, ButtonVariants}, checkbox::Checkbox, dialog::Dialog, h_flex, input::{Input, InputEvent, InputState}, select::{Select, SelectDelegate, SelectItem, SelectState}, skeleton::Skeleton, v_flex
 };
 use schema::{loader::Loader, version_manifest::{MinecraftVersionManifest, MinecraftVersionType}};
 
 use crate::{entity::{instance::InstanceEntries, metadata::{AsMetadataResult, FrontendMetadata, FrontendMetadataResult, FrontendMetadataState}}, icon::PandoraIcon, interface_config::InterfaceConfig, pages::instances_page::VersionList, ts};
 
+#[derive(Default, Clone)]
+struct LoaderVersionList {
+    versions: Vec<SharedString>,
+    matched_versions: Vec<SharedString>,
+}
+
+impl SelectDelegate for LoaderVersionList {
+    type Item = SharedString;
+
+    fn items_count(&self, _section: usize) -> usize {
+        self.matched_versions.len()
+    }
+
+    fn item(&self, ix: IndexPath) -> Option<&Self::Item> {
+        self.matched_versions.get(ix.row)
+    }
+
+    fn position<V>(&self, value: &V) -> Option<IndexPath>
+    where
+        Self::Item: SelectItem<Value = V>,
+        V: PartialEq,
+    {
+        for (ix, item) in self.matched_versions.iter().enumerate() {
+            if item.value() == value {
+                return Some(IndexPath::default().row(ix));
+            }
+        }
+
+        None
+    }
+
+    fn perform_search(&mut self, query: &str, _window: &mut Window, _: &mut Context<SelectState<Self>>) -> Task<()> {
+        let lower_query = query.to_lowercase();
+
+        self.matched_versions = self
+            .versions
+            .iter()
+            .filter(|item| item.to_lowercase().contains(&lower_query))
+            .cloned()
+            .collect();
+
+        Task::ready(())
+    }
+}
+
 struct CreateInstanceModalState {
     metadata: Entity<FrontendMetadata>,
     versions: Entity<FrontendMetadataState>,
+    loader_versions: Option<Entity<FrontendMetadataState>>,
     backend_handle: BackendHandle,
     minecraft_version_dropdown: Entity<SelectState<VersionList>>,
+    loader_version_dropdown: Entity<SelectState<LoaderVersionList>>,
     name_input_state: Entity<InputState>,
     selected_loader: Loader,
     loaded_versions: bool,
+    loaded_loader_versions: bool,
     error_loading_versions: Option<SharedString>,
+    error_loading_loader_versions: Option<SharedString>,
     name_invalid: bool,
     instance_names: Arc<[SharedString]>,
     original_fallback_name: SharedString,
@@ -26,6 +75,7 @@ struct CreateInstanceModalState {
     _versions_updated_subscription: Subscription,
     _name_input_subscription: Subscription,
     _version_selected_subscription: Subscription,
+    _loader_versions_updated_subscription: Option<Subscription>,
 }
 
 impl CreateInstanceModalState {
@@ -35,6 +85,9 @@ impl CreateInstanceModalState {
 
         let minecraft_version_dropdown =
             cx.new(|cx| SelectState::new(VersionList::default(), None, window, cx).searchable(true));
+
+        let loader_version_dropdown =
+            cx.new(|cx| SelectState::new(LoaderVersionList::default(), None, window, cx).searchable(true));
 
         let _version_selected_subscription = cx.observe_in(&minecraft_version_dropdown, window, |this, _, window, cx| {
             this.update_fallback_name(window, cx);
@@ -70,12 +123,16 @@ impl CreateInstanceModalState {
         let mut this = Self {
             metadata,
             versions,
+            loader_versions: None,
             backend_handle,
             minecraft_version_dropdown,
+            loader_version_dropdown,
             name_input_state,
             selected_loader: Loader::Vanilla,
             loaded_versions: false,
+            loaded_loader_versions: false,
             error_loading_versions: None,
+            error_loading_loader_versions: None,
             name_invalid: false,
             instance_names,
             original_fallback_name: Default::default(),
@@ -84,11 +141,158 @@ impl CreateInstanceModalState {
             _versions_updated_subscription,
             _name_input_subscription,
             _version_selected_subscription,
+            _loader_versions_updated_subscription: None,
         };
 
         this.reload_version_dropdown(window, cx);
 
         this
+    }
+
+    fn get_loader_metadata_request(loader: Loader) -> Option<MetadataRequest> {
+        match loader {
+            Loader::Fabric => Some(MetadataRequest::FabricLoaderManifest),
+            Loader::Quilt => Some(MetadataRequest::QuiltLoaderManifest),
+            Loader::Forge => Some(MetadataRequest::ForgeMavenManifest),
+            Loader::NeoForge => Some(MetadataRequest::NeoforgeMavenManifest),
+            _ => None,
+        }
+    }
+
+    fn reload_loader_versions(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(request) = Self::get_loader_metadata_request(self.selected_loader) else {
+            self.loaded_loader_versions = true;
+            self.error_loading_loader_versions = None;
+            self._loader_versions_updated_subscription = None;
+            self.loader_versions = None;
+            return;
+        };
+
+        let loader_versions = FrontendMetadata::request(&self.metadata, request, cx);
+
+        let _loader_versions_updated_subscription = cx.observe_in(&loader_versions, window, move |this, _, window, cx| {
+            this.update_loader_version_dropdown(window, cx);
+        });
+
+        self.loader_versions = Some(loader_versions);
+        self._loader_versions_updated_subscription = Some(_loader_versions_updated_subscription);
+        self.loaded_loader_versions = false;
+        self.error_loading_loader_versions = None;
+
+        self.update_loader_version_dropdown(window, cx);
+    }
+
+    fn update_loader_version_dropdown(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(loader_versions) = &self.loader_versions else {
+            return;
+        };
+
+        cx.update_entity(&self.loader_version_dropdown, |dropdown, cx| {
+            let versions: Vec<SharedString> = match self.selected_loader {
+                Loader::Fabric => {
+                    let result: FrontendMetadataResult<schema::fabric_loader_manifest::FabricLoaderManifest> = loader_versions.read(cx).result();
+                    match result {
+                        FrontendMetadataResult::Loading => {
+                            self.loaded_loader_versions = false;
+                            self.error_loading_loader_versions = None;
+                            Vec::new()
+                        },
+                        FrontendMetadataResult::Error(error) => {
+                            self.loaded_loader_versions = false;
+                            self.error_loading_loader_versions = Some(error);
+                            Vec::new()
+                        },
+                        FrontendMetadataResult::Loaded(manifest) => {
+                            self.loaded_loader_versions = true;
+                            self.error_loading_loader_versions = None;
+                            manifest.0.iter().map(|v| SharedString::from(v.version.as_str())).collect()
+                        },
+                    }
+                },
+                Loader::Quilt => {
+                    let result: FrontendMetadataResult<schema::quilt_loader_manifest::QuiltLoaderManifest> = loader_versions.read(cx).result();
+                    match result {
+                        FrontendMetadataResult::Loading => {
+                            self.loaded_loader_versions = false;
+                            self.error_loading_loader_versions = None;
+                            Vec::new()
+                        },
+                        FrontendMetadataResult::Error(error) => {
+                            self.loaded_loader_versions = false;
+                            self.error_loading_loader_versions = Some(error);
+                            Vec::new()
+                        },
+                        FrontendMetadataResult::Loaded(manifest) => {
+                            self.loaded_loader_versions = true;
+                            self.error_loading_loader_versions = None;
+                            manifest.0.iter().map(|v| SharedString::from(v.version.as_str())).collect()
+                        },
+                    }
+                },
+                Loader::Forge => {
+                    let result: FrontendMetadataResult<schema::forge::ForgeMavenManifest> = loader_versions.read(cx).result();
+                    match result {
+                        FrontendMetadataResult::Loading => {
+                            self.loaded_loader_versions = false;
+                            self.error_loading_loader_versions = None;
+                            Vec::new()
+                        },
+                        FrontendMetadataResult::Error(error) => {
+                            self.loaded_loader_versions = false;
+                            self.error_loading_loader_versions = Some(error);
+                            Vec::new()
+                        },
+                        FrontendMetadataResult::Loaded(manifest) => {
+                            self.loaded_loader_versions = true;
+                            self.error_loading_loader_versions = None;
+                            manifest.0.iter().map(|v| SharedString::from(v.as_str())).collect()
+                        },
+                    }
+                },
+                Loader::NeoForge => {
+                    let result: FrontendMetadataResult<schema::forge::NeoforgeMavenManifest> = loader_versions.read(cx).result();
+                    match result {
+                        FrontendMetadataResult::Loading => {
+                            self.loaded_loader_versions = false;
+                            self.error_loading_loader_versions = None;
+                            Vec::new()
+                        },
+                        FrontendMetadataResult::Error(error) => {
+                            self.loaded_loader_versions = false;
+                            self.error_loading_loader_versions = Some(error);
+                            Vec::new()
+                        },
+                        FrontendMetadataResult::Loaded(manifest) => {
+                            self.loaded_loader_versions = true;
+                            self.error_loading_loader_versions = None;
+                            manifest.0.iter().map(|v| SharedString::from(v.as_str())).collect()
+                        },
+                    }
+                },
+                _ => {
+                    self.loaded_loader_versions = true;
+                    self.error_loading_loader_versions = None;
+                    Vec::new()
+                }
+            };
+
+            let to_select = versions.first().cloned();
+
+            dropdown.set_items(
+                LoaderVersionList {
+                    versions: versions.clone(),
+                    matched_versions: versions,
+                },
+                window,
+                cx,
+            );
+
+            if let Some(to_select) = to_select {
+                dropdown.set_selected_value(&to_select, window, cx);
+            }
+
+            cx.notify();
+        });
     }
 
     pub fn update_fallback_name(&mut self, window: &mut Window, cx: &mut App) {
@@ -252,6 +456,11 @@ impl CreateInstanceModalState {
                         .selected(self.selected_loader == Loader::Fabric),
                 )
                 .child(
+                    Button::new("loader-quilt")
+                        .label(ts!("modrinth.category.quilt"))
+                        .selected(self.selected_loader == Loader::Quilt),
+                )
+                .child(
                     Button::new("loader-forge")
                         .label(ts!("modrinth.category.forge"))
                         .selected(self.selected_loader == Loader::Forge),
@@ -261,16 +470,42 @@ impl CreateInstanceModalState {
                         .label(ts!("modrinth.category.neoforge"))
                         .selected(self.selected_loader == Loader::NeoForge),
                 )
-                .on_click(cx.listener(move |this, selected: &Vec<usize>, _, _| {
-                    match selected.first() {
-                        Some(0) => this.selected_loader = Loader::Vanilla,
-                        Some(1) => this.selected_loader = Loader::Fabric,
-                        Some(2) => this.selected_loader = Loader::Forge,
-                        Some(3) => this.selected_loader = Loader::NeoForge,
-                        _ => {},
+                .on_click(cx.listener(move |this, selected: &Vec<usize>, window, cx| {
+                    let new_loader = match selected.first() {
+                        Some(0) => Loader::Vanilla,
+                        Some(1) => Loader::Fabric,
+                        Some(2) => Loader::Quilt,
+                        Some(3) => Loader::Forge,
+                        Some(4) => Loader::NeoForge,
+                        _ => return,
                     };
+                    if this.selected_loader != new_loader {
+                        this.selected_loader = new_loader;
+                        this.reload_loader_versions(window, cx);
+                    }
                 }))
                 .into_any_element();
+        };
+
+        // Loader version dropdown (only show for non-vanilla loaders)
+        let loader_version_element = if self.selected_loader != Loader::Vanilla {
+            if !self.loaded_loader_versions {
+                Some(Select::new(&self.loader_version_dropdown)
+                    .w_full()
+                    .disabled(true)
+                    .placeholder(ts!("instance.versions_loading.loader_versions"))
+                    .into_any_element())
+            } else if let Some(error) = &self.error_loading_loader_versions {
+                Some(Alert::new("loader-error", format!("{}", error))
+                    .icon(PandoraIcon::CircleX)
+                    .into_any_element())
+            } else {
+                Some(Select::new(&self.loader_version_dropdown)
+                    .title_prefix(format!("{}: ", ts!("instance.loader_version")))
+                    .into_any_element())
+            }
+        } else {
+            None
         };
 
         let content = v_flex()
@@ -280,7 +515,7 @@ impl CreateInstanceModalState {
                 Input::new(&self.name_input_state).when(self.name_invalid, |this| this.border_color(cx.theme().danger)),
             ))
             .child(crate::labelled(ts!("instance.version"), v_flex().gap_2().child(version_dropdown).child(show_snapshots_button)))
-            .child(crate::labelled(ts!("instance.modloader"), loader_button_group))
+            .child(crate::labelled(ts!("instance.modloader"), v_flex().gap_2().child(loader_button_group).when_some(loader_version_element, |this, el| this.child(el))))
             .child(h_flex().child(Button::new("icon").icon(PandoraIcon::Plus).label(ts!("instance.select_icon")).on_click({
                 let entity = cx.entity();
                 move |_, window, cx| {

--- a/crates/frontend/src/pages/instance/settings_subpage.rs
+++ b/crates/frontend/src/pages/instance/settings_subpage.rs
@@ -7,7 +7,7 @@ use gpui::{prelude::*, *};
 use gpui_component::{
     ActiveTheme as _, Disableable, IndexPath, Sizable, WindowExt, button::{Button, ButtonVariants}, checkbox::Checkbox, h_flex, input::{Input, InputEvent, InputState, NumberInput, NumberInputEvent}, notification::{Notification, NotificationType}, select::{SearchableVec, Select, SelectEvent, SelectState}, skeleton::Skeleton, v_flex
 };
-use schema::{fabric_loader_manifest::FabricLoaderManifest, forge::{ForgeMavenManifest, NeoforgeMavenManifest}, instance::{AUTO_LIBRARY_PATH_GLFW, AUTO_LIBRARY_PATH_OPENAL, InstanceJvmBinaryConfiguration, InstanceJvmFlagsConfiguration, InstanceLinuxWrapperConfiguration, InstanceMemoryConfiguration, InstanceSystemLibrariesConfiguration, InstanceWrapperCommandConfiguration, LwjglLibraryPath}, loader::Loader, version_manifest::MinecraftVersionManifest};
+use schema::{fabric_loader_manifest::FabricLoaderManifest, forge::{ForgeMavenManifest, NeoforgeMavenManifest}, instance::{AUTO_LIBRARY_PATH_GLFW, AUTO_LIBRARY_PATH_OPENAL, InstanceJvmBinaryConfiguration, InstanceJvmFlagsConfiguration, InstanceMemoryConfiguration, InstanceSystemLibrariesConfiguration, InstanceWrapperCommandConfiguration, LwjglLibraryPath}, loader::Loader, quilt_loader_manifest::QuiltLoaderManifest, version_manifest::MinecraftVersionManifest};
 use strum::IntoEnumIterator;
 use uuid::Uuid;
 
@@ -296,6 +296,13 @@ impl InstanceSettingsSubpage {
             },
             Loader::Fabric => {
                 self.update_loader_versions_for_loader(MetadataRequest::FabricLoaderManifest, |manifest: &FabricLoaderManifest| {
+                    std::iter::once("Latest")
+                        .chain(manifest.0.iter().map(|s| s.version.as_str()))
+                        .collect()
+                }, window, cx)
+            },
+            Loader::Quilt => {
+                self.update_loader_versions_for_loader(MetadataRequest::QuiltLoaderManifest, |manifest: &QuiltLoaderManifest| {
                     std::iter::once("Latest")
                         .chain(manifest.0.iter().map(|s| s.version.as_str()))
                         .collect()
@@ -737,6 +744,7 @@ impl Render for InstanceSettingsSubpage {
                 TypelessFrontendMetadataResult::Loaded => {
                     version_content = version_content.child(Select::new(&self.loader_version_select_state).title_prefix(match self.loader {
                         Loader::Fabric => format!("{}: ", ts!("instance.loader_version", loader = ts!("modrinth.category.fabric"))),
+                        Loader::Quilt => format!("{}: ", ts!("instance.loader_version", loader = ts!("modrinth.category.quilt"))),
                         Loader::Forge => format!("{}: ", ts!("instance.loader_version", loader = ts!("modrinth.category.forge"))),
                         Loader::NeoForge => format!("{}: ", ts!("instance.loader_version", loader = ts!("modrinth.category.neoforge"))),
                         Loader::Vanilla | Loader::Unknown => format!("{}: ", ts!("instance.loader_version", loader = ts!("instance.loader"))),

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -9,6 +9,7 @@ pub mod fabric_launch;
 pub mod fabric_loader_manifest;
 pub mod fabric_mod;
 pub mod forge;
+pub mod quilt_loader_manifest;
 pub mod forge_mod;
 pub mod instance;
 pub mod java_runtime_component;

--- a/crates/schema/src/loader.rs
+++ b/crates/schema/src/loader.rs
@@ -14,6 +14,8 @@ pub enum Loader {
     Forge,
     #[serde(alias = "NeoForge")]
     NeoForge,
+    #[serde(alias = "Quilt")]
+    Quilt,
     #[serde(other)]
     Unknown,
 }
@@ -25,6 +27,7 @@ impl Loader {
             Loader::Fabric => "Fabric",
             Loader::Forge => "Forge",
             Loader::NeoForge => "NeoForge",
+            Loader::Quilt => "Quilt",
             Loader::Unknown => "Unknown",
         }
     }
@@ -35,6 +38,7 @@ impl Loader {
             "Fabric" | "fabric" => Self::Fabric,
             "Forge" | "forge" => Self::Forge,
             "NeoForge" | "neoforge" => Self::NeoForge,
+            "Quilt" | "quilt" => Self::Quilt,
             _ => Self::Unknown,
         }
     }
@@ -45,6 +49,7 @@ impl Loader {
             Loader::Fabric => ModrinthLoader::Fabric,
             Loader::Forge => ModrinthLoader::Forge,
             Loader::NeoForge => ModrinthLoader::NeoForge,
+            Loader::Quilt => ModrinthLoader::Quilt,
             Loader::Unknown => ModrinthLoader::Unknown,
         }
     }
@@ -55,6 +60,7 @@ impl Loader {
             Loader::Fabric => CurseforgeModLoaderType::Fabric,
             Loader::Forge => CurseforgeModLoaderType::Forge,
             Loader::NeoForge => CurseforgeModLoaderType::NeoForge,
+            Loader::Quilt => CurseforgeModLoaderType::Quilt,
             Loader::Unknown => CurseforgeModLoaderType::Any,
         }
     }

--- a/crates/schema/src/modrinth.rs
+++ b/crates/schema/src/modrinth.rs
@@ -141,6 +141,7 @@ pub enum ModrinthLoader {
     Fabric,
     Forge,
     NeoForge,
+    Quilt,
     // Resourcepacks
     Minecraft,
     // Shaders
@@ -155,7 +156,7 @@ pub enum ModrinthLoader {
 impl ModrinthLoader {
     pub fn install_directory(self) -> Option<&'static str> {
         match self {
-            ModrinthLoader::Fabric | ModrinthLoader::Forge | ModrinthLoader::NeoForge => Some("mods"),
+            ModrinthLoader::Fabric | ModrinthLoader::Forge | ModrinthLoader::NeoForge | ModrinthLoader::Quilt => Some("mods"),
             ModrinthLoader::Minecraft => Some("resourcepacks"),
             ModrinthLoader::Iris | ModrinthLoader::Optifine => Some("shaderpacks"),
             ModrinthLoader::Canvas => Some("resourcepacks"),
@@ -168,6 +169,7 @@ impl ModrinthLoader {
             Self::Fabric => "Fabric",
             Self::Forge => "Forge",
             Self::NeoForge => "NeoForge",
+            Self::Quilt => "Quilt",
             Self::Minecraft => "Minecraft",
             Self::Iris => "Iris",
             Self::Optifine => "Optifine",
@@ -181,6 +183,7 @@ impl ModrinthLoader {
             Self::Fabric => "fabric",
             Self::Forge => "forge",
             Self::NeoForge => "neoforge",
+            Self::Quilt => "quilt",
             Self::Minecraft => "minecraft",
             Self::Iris => "iris",
             Self::Optifine => "optifine",
@@ -194,6 +197,7 @@ impl ModrinthLoader {
             "Fabric" | "fabric" => Self::Fabric,
             "Forge" | "forge" => Self::Forge,
             "NeoForge" | "neoforge" => Self::NeoForge,
+            "Quilt" | "quilt" => Self::Quilt,
             "Minecraft" | "minecraft" => Self::Minecraft,
             "Iris" | "iris" => Self::Iris,
             "Optifine" | "optifine" => Self::Optifine,

--- a/crates/schema/src/quilt_loader_manifest.rs
+++ b/crates/schema/src/quilt_loader_manifest.rs
@@ -1,0 +1,15 @@
+use serde::Deserialize;
+use ustr::Ustr;
+
+pub const QUILT_LOADER_MANIFEST_URL: &str = "https://meta.quiltmc.org/v3/versions/loader";
+
+#[derive(Deserialize, Debug)]
+pub struct QuiltLoaderManifest(pub Vec<QuiltLoaderVersion>);
+
+#[derive(Deserialize, Debug)]
+pub struct QuiltLoaderVersion {
+    pub separator: Ustr,
+    pub build: usize,
+    pub maven: Ustr,
+    pub version: Ustr,
+}


### PR DESCRIPTION
## Summary
This PR adds complete Quilt mod loader support and fixes several compilation errors.

## Changes
- Added QuiltLoaderManifest schema and metadata handling
- Added quilt_launch field to MetadataManagerStates 
- Fixed LoaderVersionList to implement SelectDelegate trait instead of non-existent SelectItems
- Added Loader::Quilt variant handling in settings_subpage.rs
- Added AsMetadataResult implementation for QuiltLoaderManifest

## Files Modified
- crates/schema/src/quilt_loader_manifest.rs (new)
- crates/schema/src/lib.rs
- crates/schema/src/loader.rs
- crates/bridge/src/meta.rs
- crates/backend/src/metadata/manager.rs
- crates/backend/src/metadata/items.rs
- crates/frontend/src/entity/metadata.rs
- crates/frontend/src/modals/create_instance.rs
- crates/frontend/src/pages/instance/settings_subpage.rs

## Testing
- Project compiles successfully with cargo build --release
- cargo check passes without errors