### PR TITLE
Playtime tracking on the instance page and individual instances

### DIFF
--- a/crates/backend/src/backend.rs
+++ b/crates/backend/src/backend.rs
@@ -378,6 +378,7 @@ impl BackendState {
                 servers_state: instance.servers_state.clone(),
                 mods_state: instance.content_state[ContentFolder::Mods].load_state.clone(),
                 resource_packs_state: instance.content_state[ContentFolder::ResourcePacks].load_state.clone(),
+                play_time_seconds: instance.play_time_seconds,
             };
             self.send.send(message);
 
@@ -435,6 +436,9 @@ impl BackendState {
                 }
             });
             if changed {
+                if instance.processes.is_empty() {
+                    instance.end_session();
+                }
                 self.send.send(instance.create_modify_message());
             }
         }

--- a/crates/backend/src/backend_handler.rs
+++ b/crates/backend/src/backend_handler.rs
@@ -186,6 +186,8 @@ impl BackendState {
                     return;
                 }
 
+                instance.end_session();
+
                 for mut process in instance.processes.drain(..) {
                     let result = process.kill();
                     if result.is_err() {
@@ -271,6 +273,7 @@ impl BackendState {
                         child.stdout.take();
 
                         if let Some(instance) = self.instance_state.write().instances.get_mut(id) {
+                            instance.start_session();
                             instance.processes.push(child);
                         }
                     },

--- a/crates/backend/src/instance.rs
+++ b/crates/backend/src/instance.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashSet, hash::{DefaultHasher, Hash, Hasher}, io::Read, path::Path, process::Child, sync::Arc
+    collections::HashSet, hash::{DefaultHasher, Hash, Hasher}, io::Read, path::Path, process::Child, sync::Arc, time::Instant
 };
 
 use anyhow::Context;
@@ -33,6 +33,8 @@ pub struct Instance {
 
     pub launch_keepalive: Option<KeepAliveHandle>,
     pub processes: Vec<Child>,
+    pub session_start: Option<Instant>,
+    pub play_time_seconds: u64,
 
     pub worlds_state: BridgeDataLoadState,
     dirty_worlds: FolderChanges,
@@ -700,6 +702,25 @@ impl Instance {
         summaries
     }
 
+    pub fn start_session(&mut self) {
+        self.session_start = Some(Instant::now());
+    }
+
+    pub fn end_session(&mut self) {
+        if let Some(start) = self.session_start.take() {
+            self.play_time_seconds += start.elapsed().as_secs();
+            self.save_play_time();
+        }
+    }
+
+    fn save_play_time(&self) {
+        #[derive(serde::Serialize)]
+        struct PlaytimeData { seconds: u64 }
+        if let Ok(bytes) = serde_json::to_vec(&PlaytimeData { seconds: self.play_time_seconds }) {
+            let _ = crate::write_safe(&self.root_path.join("playtime_v1.json"), &bytes);
+        }
+    }
+
     pub fn load_from_folder(path: impl AsRef<Path>) -> Result<Self, InstanceLoadError> {
         let path = path.as_ref();
         log::info!("Loading instance from {:?}", path);
@@ -729,6 +750,8 @@ impl Instance {
         let icon_path = path.join("icon.png");
         let icon = std::fs::read(icon_path).ok().map(|v| v.into());
 
+        let play_time_seconds = load_play_time(path);
+
         Ok(Self {
             id: InstanceID::dangling(),
             root_path: path.into(),
@@ -741,6 +764,8 @@ impl Instance {
 
             launch_keepalive: None,
             processes: Vec::new(),
+            session_start: None,
+            play_time_seconds,
 
             worlds_state: BridgeDataLoadState::default(),
             dirty_worlds: FolderChanges::all_dirty(),
@@ -858,6 +883,7 @@ impl Instance {
             dot_minecraft_folder: self.dot_minecraft_path.clone(),
             configuration: self.configuration.get().clone(),
             status: self.status(),
+            play_time_seconds: self.play_time_seconds,
         }
     }
 
@@ -873,6 +899,14 @@ impl Instance {
             self.root_path.clone()
         }
     }
+}
+
+fn load_play_time(root_path: &Path) -> u64 {
+    #[derive(serde::Deserialize)]
+    struct PlaytimeData { seconds: u64 }
+    crate::read_json::<PlaytimeData>(&root_path.join("playtime_v1.json"))
+        .map(|d| d.seconds)
+        .unwrap_or(0)
 }
 
 fn create_instance_content_summary(path: &Path, mod_metadata_manager: &Arc<ModMetadataManager>, for_loader: Loader, for_version: Ustr) -> Option<InstanceContentSummary> {

--- a/crates/backend/src/launcher_import/multimc.rs
+++ b/crates/backend/src/launcher_import/multimc.rs
@@ -376,6 +376,18 @@ struct MultiMCInstanceToImport {
     multimc_instance_cfg: PathBuf,
     multimc_mmc_pack: PathBuf,
     folder: PathBuf,
+    total_time_played: Option<u64>,
+}
+
+fn read_total_time_played(instance_cfg: &Path) -> Option<u64> {
+    let content = std::fs::read_to_string(instance_cfg).ok()?;
+    for line in content.split('\n') {
+        let line = line.trim();
+        if let Some(value) = line.strip_prefix("totalTimePlayed=") {
+            return value.trim().parse::<u64>().ok();
+        }
+    }
+    None
 }
 
 fn import_instances_from_multimc(backend: &BackendState, path: &Path, modal_action: &ModalAction) {
@@ -415,11 +427,13 @@ fn import_instances_from_multimc(backend: &BackendState, path: &Path, modal_acti
             continue;
         }
 
+        let total_time_played = read_total_time_played(&multimc_instance_cfg);
         to_import.push(MultiMCInstanceToImport {
             pandora_path,
             multimc_instance_cfg,
             multimc_mmc_pack,
             folder,
+            total_time_played,
         });
     }
 
@@ -465,12 +479,21 @@ fn import_instances_from_multimc(backend: &BackendState, path: &Path, modal_acti
             });
         }
 
-        // Copy icon
         _ = std::fs::copy(to_import.folder.join("icon.png"), to_import.pandora_path.join("icon.png"));
 
-        // Write info_v1.json
+        // actually write info_v1.json
         let info_path = to_import.pandora_path.join("info_v1.json");
         _ = crate::write_safe(&info_path, &configuration_bytes);
+
+        // Write playtime_v1.json if PrismLauncher saved playtime
+        if let Some(seconds) = to_import.total_time_played {
+            #[derive(serde::Serialize)]
+            struct PlaytimeData { seconds: u64 }
+            if let Ok(bytes) = serde_json::to_vec(&PlaytimeData { seconds }) {
+                let playtime_path = to_import.pandora_path.join("playtime_v1.json");
+                _ = crate::write_safe(&playtime_path, &bytes);
+            }
+        }
 
         all_tracker.add_count(1);
         all_tracker.notify();

--- a/crates/bridge/src/message.rs
+++ b/crates/bridge/src/message.rs
@@ -251,6 +251,7 @@ pub enum MessageToFrontend {
         servers_state: BridgeDataLoadState,
         mods_state: BridgeDataLoadState,
         resource_packs_state: BridgeDataLoadState,
+        play_time_seconds: u64,
     },
     InstanceRemoved {
         id: InstanceID,
@@ -263,6 +264,7 @@ pub enum MessageToFrontend {
         dot_minecraft_folder: Arc<Path>,
         configuration: InstanceConfiguration,
         status: InstanceStatus,
+        play_time_seconds: u64,
     },
     InstanceWorldsUpdated {
         id: InstanceID,

--- a/crates/frontend/locales/locales.yml
+++ b/crates/frontend/locales/locales.yml
@@ -370,6 +370,11 @@ instance:
   create:
     en: Create Instance
 
+  playtime:
+    en: Play Time
+  total_playtime:
+    en: Total play time
+
   # Properties & Config
   name:
     en: Name

--- a/crates/frontend/src/component/instance_list.rs
+++ b/crates/frontend/src/component/instance_list.rs
@@ -1,4 +1,20 @@
 use bridge::{handle::BackendHandle, instance::InstanceStatus, message::MessageToBackend};
+
+pub(crate) fn format_playtime(seconds: u64) -> SharedString {
+    if seconds == 0 {
+        return "Never played".into();
+    }
+    let h = seconds / 3600;
+    let m = (seconds % 3600) / 60;
+    let s = seconds % 60;
+    if h > 0 {
+        format!("{}h {}m {}s", h, m, s).into()
+    } else if m > 0 {
+        format!("{}m {}s", m, s).into()
+    } else {
+        format!("{}s", s).into()
+    }
+}
 use gpui::{prelude::*, *};
 use gpui_component::{
     button::{Button, ButtonVariants}, h_flex, table::{Column, ColumnSort, TableDelegate, TableState}, v_flex, ActiveTheme, Icon, Sizable
@@ -61,6 +77,10 @@ impl InstanceList {
                         .width(150.)
                         .fixed_left()
                         .resizable(true),
+                    Column::new("playtime", ts!("instance.playtime"))
+                        .width(150.)
+                        .fixed_left()
+                        .resizable(true),
                 ],
                 items,
                 backend_handle: data.backend_handle.clone(),
@@ -92,6 +112,7 @@ impl InstanceList {
         };
 
         let play_button = render_play_button(item, index, self.backend_handle.clone());
+        let playtime = format_playtime(item.play_time_seconds);
 
         let theme = cx.theme();
         v_flex()
@@ -112,6 +133,7 @@ impl InstanceList {
                     .w_full()
                     .child(item.name.clone())
                     .child(loader_and_version)
+                    .child(playtime)
                 )
             ).child(h_flex()
                 .gap_2()
@@ -186,6 +208,7 @@ impl TableDelegate for InstanceList {
                         .into_any_element()
                 },
                 "loader" => item.configuration.loader.name().into_any_element(),
+                "playtime" => format_playtime(item.play_time_seconds).into_any_element(),
                 _ => ts!("common.unknown").into_any_element(),
             }
         } else {

--- a/crates/frontend/src/entity/instance.rs
+++ b/crates/frontend/src/entity/instance.rs
@@ -26,6 +26,7 @@ impl InstanceEntries {
         servers_state: BridgeDataLoadState,
         mods_state: BridgeDataLoadState,
         resource_packs_state: BridgeDataLoadState,
+        play_time_seconds: u64,
         cx: &mut App,
     ) {
         entity.update(cx, |entries, cx| {
@@ -46,6 +47,7 @@ impl InstanceEntries {
                 mods: cx.new(|_| [].into()),
                 resource_packs_state,
                 resource_packs: cx.new(|_| [].into()),
+                play_time_seconds,
             };
             instance.title = instance.create_title();
 
@@ -97,6 +99,7 @@ impl InstanceEntries {
         dot_minecraft_folder: Arc<Path>,
         configuration: InstanceConfiguration,
         status: InstanceStatus,
+        play_time_seconds: u64,
         cx: &mut App,
     ) {
         entity.update(cx, |entries, cx| {
@@ -108,6 +111,7 @@ impl InstanceEntries {
                     instance.dot_minecraft_folder = dot_minecraft_folder.clone();
                     instance.configuration = configuration.clone();
                     instance.status = status;
+                    instance.play_time_seconds = play_time_seconds;
                     instance.title = instance.create_title();
                     cx.notify();
 
@@ -204,6 +208,7 @@ pub struct InstanceEntry {
     pub dot_minecraft_folder: Arc<Path>,
     pub configuration: InstanceConfiguration,
     pub status: InstanceStatus,
+    pub play_time_seconds: u64,
     pub worlds_state: BridgeDataLoadState,
     pub worlds: Entity<Arc<[InstanceWorldSummary]>>,
     pub servers_state: BridgeDataLoadState,

--- a/crates/frontend/src/pages/instances_page.rs
+++ b/crates/frontend/src/pages/instances_page.rs
@@ -1,12 +1,12 @@
 use bridge::handle::BackendHandle;
 use gpui::{prelude::*, *};
 use gpui_component::{
-    IndexPath, button::{Button, ButtonVariants}, h_flex, select::{Select, SelectDelegate, SelectEvent, SelectItem, SelectState}, table::{DataTable, TableDelegate, TableState}
+    ActiveTheme as _, IndexPath, button::{Button, ButtonVariants}, h_flex, scroll::ScrollableElement as _, select::{Select, SelectDelegate, SelectEvent, SelectItem, SelectState}, table::{DataTable, TableDelegate, TableState}, v_flex
 };
 use strum::IntoEnumIterator;
 
 use crate::{
-    component::{instance_list::InstanceList, named_dropdown::{NamedDropdown, NamedDropdownItem}, responsive_grid::ResponsiveGrid}, entity::{DataEntities, instance::InstanceEntries, metadata::FrontendMetadata}, icon::PandoraIcon, interface_config::{InstancesViewMode, InterfaceConfig}, pages::page::Page, ts
+    component::{instance_list::{InstanceList, format_playtime}, named_dropdown::{NamedDropdown, NamedDropdownItem}, responsive_grid::ResponsiveGrid}, entity::{DataEntities, instance::InstanceEntries, metadata::FrontendMetadata}, icon::PandoraIcon, interface_config::{InstancesViewMode, InterfaceConfig}, pages::page::Page, ts
 };
 
 pub struct InstancesPage {
@@ -65,17 +65,19 @@ impl Page for InstancesPage {
         h_flex().gap_3().child(create_instance).child(select_view)
     }
 
-    fn scrollable(&self, cx: &App) -> bool {
-        match InterfaceConfig::get(cx).instances_view_mode {
-            InstancesViewMode::Cards => true,
-            InstancesViewMode::List => false,
-        }
+    fn scrollable(&self, _cx: &App) -> bool {
+        false
     }
 }
 
+// wrap in .div().relative() so overlay can be positioned absolutly
 impl Render for InstancesPage {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        match InterfaceConfig::get(cx).instances_view_mode {
+        let total_playtime = self.instances.read(cx).entries.values()
+            .map(|e| e.read(cx).play_time_seconds)
+            .sum::<u64>();
+
+        let content: AnyElement = match InterfaceConfig::get(cx).instances_view_mode {
             InstancesViewMode::Cards => {
                 let cards = self.instance_table.update(cx, |table, cx| {
                     let rows = table.delegate().rows_count(cx);
@@ -87,12 +89,36 @@ impl Render for InstancesPage {
                     gpui::AvailableSpace::MinContent
                 );
 
-                div().p_4().child(ResponsiveGrid::new(size).size_full().gap_4().children(cards)).into_any_element()
+                div()
+                    .flex_1()
+                    .overflow_hidden()
+                    .child(v_flex().size_full().overflow_y_scrollbar()
+                        .child(div().p_4().child(ResponsiveGrid::new(size).size_full().gap_4().children(cards))))
+                    .into_any_element()
             },
             InstancesViewMode::List => {
                 DataTable::new(&self.instance_table).bordered(false).into_any_element()
             },
-        }
+        };
+
+        let theme = cx.theme();
+        div()
+            .relative()
+            .size_full()
+            .child(content)
+            .child(
+                div()
+                    .absolute()
+                    .bottom_4()
+                    .right_4()
+                    .px_3()
+                    .py_2()
+                    .rounded(theme.radius)
+                    .bg(theme.background)
+                    .border_1()
+                    .border_color(theme.border)
+                    .child(format!("{}: {}", ts!("instance.total_playtime"), format_playtime(total_playtime)))
+            )
     }
 }
 

--- a/crates/frontend/src/processor.rs
+++ b/crates/frontend/src/processor.rs
@@ -67,6 +67,7 @@ impl Processor {
                 servers_state,
                 mods_state,
                 resource_packs_state,
+                play_time_seconds,
             } => {
                 InstanceEntries::add(
                     &self.data.instances,
@@ -80,6 +81,7 @@ impl Processor {
                     servers_state,
                     mods_state,
                     resource_packs_state,
+                    play_time_seconds,
                     cx,
                 );
             },
@@ -94,6 +96,7 @@ impl Processor {
                 dot_minecraft_folder,
                 configuration,
                 status,
+                play_time_seconds,
             } => {
                 if status == InstanceStatus::Running {
                     if InterfaceConfig::get(cx).hide_main_window_on_launch {
@@ -121,6 +124,7 @@ impl Processor {
                     dot_minecraft_folder,
                     configuration,
                     status,
+                    play_time_seconds,
                     cx,
                 );
             },


### PR DESCRIPTION
- Playtime will also transfer over from Prismlauncher instances
- instances page is now wraped in a div().relative() so the overlay can be absolutely positioned
- scrolling is internal now so the box in the bottom right  stays pinned
- #272 
<img width="1605" height="932" alt="Pandora" src="https://github.com/user-attachments/assets/dd3fc891-836f-4c47-9fdb-1c3c7e2788ce" />
