### PR TITLE
Add server list reorder and persist to servers.dat

### DIFF
--- a/crates/backend/src/backend.rs
+++ b/crates/backend/src/backend.rs
@@ -147,6 +147,7 @@ pub fn start(launcher_dir: PathBuf, send: FrontendHandle, self_handle: BackendHa
         cached_minecraft_profiles: Default::default(),
         skin_manager: Default::default(),
         server_list_pinger: Arc::new(ServerListPinger::new()),
+        server_dat_ignore: Default::default(),
     };
 
     log::debug!("Doing initial backend load");
@@ -205,6 +206,7 @@ pub struct BackendState {
     pub cached_minecraft_profiles: Arc<RwLock<FxHashMap<Uuid, CachedMinecraftProfile>>>,
     pub skin_manager: Arc<RwLock<SkinManager>>,
     pub server_list_pinger: Arc<ServerListPinger>,
+    pub server_dat_ignore: Arc<RwLock<FxHashMap<InstanceID, u8>>>,
 }
 
 pub struct CachedMinecraftProfile {

--- a/crates/backend/src/backend_filesystem.rs
+++ b/crates/backend/src/backend_filesystem.rs
@@ -366,7 +366,16 @@ impl BackendState {
                             return;
                         },
                         "servers.dat" => {
-                            after_debounce_effects.server_dat_changes.insert(id);
+                            let mut ignore = self.server_dat_ignore.write();
+                            if let Some(count) = ignore.get_mut(&id) {
+                                if *count > 1 {
+                                    *count -= 1;
+                                } else {
+                                    ignore.remove(&id);
+                                }
+                            } else {
+                                after_debounce_effects.server_dat_changes.insert(id);
+                            }
                             return;
                         },
                         _ => {},
@@ -442,7 +451,16 @@ impl BackendState {
                     return;
                 };
                 if file_name == "servers.dat" {
-                    after_debounce_effects.server_dat_changes.insert(id);
+                    let mut ignore = self.server_dat_ignore.write();
+                    if let Some(count) = ignore.get_mut(&id) {
+                        if *count > 1 {
+                            *count -= 1;
+                        } else {
+                            ignore.remove(&id);
+                        }
+                    } else {
+                        after_debounce_effects.server_dat_changes.insert(id);
+                    }
                 }
             }
             WatchTarget::InstanceWorldDir { id } => {

--- a/crates/backend/src/backend_handler.rs
+++ b/crates/backend/src/backend_handler.rs
@@ -75,6 +75,9 @@ impl BackendState {
             MessageToBackend::RequestLoadServers { id } => {
                 tokio::task::spawn(Instance::load_servers(self.clone(), id));
             },
+            MessageToBackend::ReorderServers { id, from_index, to_index } => {
+                tokio::task::spawn(Instance::reorder_servers(self.clone(), id, from_index, to_index));
+            },
             MessageToBackend::RequestLoadMods { id } => {
                 tokio::task::spawn(Instance::load_content(self.clone(), id, ContentFolder::Mods));
             },

--- a/crates/backend/src/instance.rs
+++ b/crates/backend/src/instance.rs
@@ -382,6 +382,55 @@ impl Instance {
         Self::load_servers_inner(backend, id).await
     }
 
+    pub async fn reorder_servers(
+        backend: Arc<BackendState>,
+        id: InstanceID,
+        from_index: usize,
+        to_index: usize,
+    ) {
+        backend.server_dat_ignore.write().insert(id, 2);
+        let server_dat_path = {
+            let guard = backend.instance_state.read();
+            let Some(instance) = guard.instances.get(id) else {
+                backend.server_dat_ignore.write().remove(&id);
+                return;
+            };
+            instance.server_dat_path.clone()
+        };
+
+        let result = tokio::task::spawn_blocking(move || {
+            reorder_servers_in_file(&server_dat_path, from_index, to_index)
+        }).await;
+
+        match result {
+            Ok(Ok(changed)) => {
+                if changed {
+                    if let Some(instance) = backend.instance_state.write().instances.get_mut(id) {
+                        if let Some(servers) = instance.servers.as_ref() {
+                            if let Some(updated) = reorder_servers_in_memory(servers, from_index, to_index) {
+                                instance.servers = Some(updated.clone());
+                                backend.send.send(MessageToFrontend::InstanceServersUpdated {
+                                    id,
+                                    servers: updated,
+                                });
+                            }
+                        }
+                    }
+                }
+            },
+            Ok(Err(err)) => {
+                backend.server_dat_ignore.write().remove(&id);
+                log::error!("Error reordering servers: {:?}", err);
+                backend.send.send_error(format!("Error reordering servers: {err}"));
+            },
+            Err(err) => {
+                backend.server_dat_ignore.write().remove(&id);
+                log::error!("Error reordering servers: {:?}", err);
+                backend.send.send_error(format!("Error reordering servers: {err}"));
+            },
+        }
+    }
+
     fn load_servers_inner(
         backend: Arc<BackendState>,
         id: InstanceID,
@@ -1138,4 +1187,46 @@ fn load_servers_summary(server_dat_path: &Path, backend: &Arc<BackendState>, ver
     }
 
     Ok(summaries)
+}
+
+fn reorder_servers_in_file(server_dat_path: &Path, from_index: usize, to_index: usize) -> anyhow::Result<bool> {
+    if !server_dat_path.is_file() {
+        return Ok(false);
+    }
+
+    let raw = std::fs::read(server_dat_path)?;
+    let mut nbt_data = raw.as_slice();
+    let mut result = nbt::decode::read_named(&mut nbt_data)?;
+
+    let mut root = result.as_compound_mut().context("Unable to get root compound")?;
+    let mut servers = root
+        .find_list_mut("servers", nbt::TAG_COMPOUND_ID)
+        .context("Unable to get servers")?;
+
+    if !servers.move_index(from_index, to_index) {
+        return Ok(false);
+    }
+
+    let bytes = nbt::encode::write_named(&result);
+    let temp_path = server_dat_path.with_extension("dat.tmp");
+    std::fs::write(&temp_path, bytes)?;
+    let _ = std::fs::remove_file(server_dat_path);
+    std::fs::rename(&temp_path, server_dat_path)?;
+    Ok(true)
+}
+
+fn reorder_servers_in_memory(
+    servers: &Arc<[InstanceServerSummary]>,
+    from_index: usize,
+    to_index: usize,
+) -> Option<Arc<[InstanceServerSummary]>> {
+    if from_index >= servers.len() || to_index >= servers.len() || from_index == to_index {
+        return None;
+    }
+
+    let mut vec = servers.to_vec();
+    let entry = vec.remove(from_index);
+    let insert_at = to_index.min(vec.len());
+    vec.insert(insert_at, entry);
+    Some(vec.into())
 }

--- a/crates/bridge/src/message.rs
+++ b/crates/bridge/src/message.rs
@@ -105,6 +105,11 @@ pub enum MessageToBackend {
     RequestLoadServers {
         id: InstanceID,
     },
+    ReorderServers {
+        id: InstanceID,
+        from_index: usize,
+        to_index: usize,
+    },
     RequestLoadMods {
         id: InstanceID,
     },

--- a/crates/frontend/src/pages/instance/quickplay_subpage.rs
+++ b/crates/frontend/src/pages/instance/quickplay_subpage.rs
@@ -8,7 +8,7 @@ use bridge::{
 };
 use gpui::{prelude::*, *};
 use gpui_component::{
-    ActiveTheme as _, Colorize, IndexPath, Theme, button::{Button, ButtonVariants}, h_flex, list::{ListDelegate, ListItem, ListState}, v_flex
+    ActiveTheme as _, Colorize, Disableable, IndexPath, Sizable, Theme, button::{Button, ButtonVariants}, h_flex, list::{ListDelegate, ListItem, ListState}, v_flex
 };
 
 use crate::{
@@ -52,8 +52,10 @@ impl InstanceQuickplaySubpage {
             id: instance_id,
             name: instance.name.clone(),
             backend_handle: backend_handle.clone(),
+            servers_entity: instance.servers.clone(),
             servers: instance.servers.read(cx).to_vec(),
             searched: instance.servers.read(cx).to_vec(),
+            search_query: String::new(),
         };
 
         let worlds = instance.worlds.clone();
@@ -77,8 +79,7 @@ impl InstanceQuickplaySubpage {
             cx.observe(&servers, |list: &mut ListState<ServersListDelegate>, servers, cx| {
                 let servers = servers.read(cx).to_vec();
                 let delegate = list.delegate_mut();
-                delegate.servers = servers.clone();
-                delegate.searched = servers;
+                delegate.set_servers(servers);
                 cx.notify();
             })
             .detach();
@@ -289,8 +290,10 @@ pub struct ServersListDelegate {
     id: InstanceID,
     name: SharedString,
     backend_handle: BackendHandle,
+    servers_entity: Entity<Arc<[InstanceServerSummary]>>,
     servers: Vec<InstanceServerSummary>,
     searched: Vec<InstanceServerSummary>,
+    search_query: String,
 }
 
 impl ListDelegate for ServersListDelegate {
@@ -311,6 +314,7 @@ impl ListDelegate for ServersListDelegate {
         let hide_server_addresses = interface_config.hide_server_addresses;
 
         let summary = self.searched.get(ix.row)?;
+        let can_reorder = self.can_reorder();
 
         let icon = if let Some(png_icon) = summary.png_icon.as_ref() {
             png_render_cache::render(Arc::clone(png_icon), cx)
@@ -389,26 +393,60 @@ impl ListDelegate for ServersListDelegate {
         let name = self.name.clone();
         let backend_handle = self.backend_handle.clone();
         let target = OsString::from(summary.ip.to_string());
-        let item = ListItem::new(ix).p_1().child(
-            h_flex()
-                .gap_1()
-                .child(
-                    div()
-                        .child(Button::new(ix).success().icon(PandoraIcon::Play).on_click(move |_, window, cx| {
-                            root::start_instance(
-                                id,
-                                name.clone(),
-                                Some(QuickPlayLaunch::Multiplayer(target.clone())),
-                                &backend_handle,
-                                window,
-                                cx,
-                            );
-                        }))
-                        .px_2(),
-                )
-                .child(icon.size_16().min_w_16().min_h_16())
-                .child(description),
-        );
+        let row_index = ix.row;
+
+        let move_up = Button::new(("server-up", row_index))
+            .compact()
+            .small()
+            .icon(PandoraIcon::ArrowUp)
+            .disabled(!can_reorder || row_index == 0)
+            .on_click(cx.listener(move |this, _, _, cx| {
+                if !this.delegate().can_reorder() || row_index == 0 {
+                    return;
+                }
+                this.delegate_mut().reorder_servers(row_index, row_index.saturating_sub(1), cx);
+            }));
+
+        let move_down = Button::new(("server-down", row_index))
+            .compact()
+            .small()
+            .icon(PandoraIcon::ArrowDown)
+            .disabled(!can_reorder || row_index + 1 >= self.searched.len())
+            .on_click(cx.listener(move |this, _, _, cx| {
+                let last_index = this.delegate().searched.len().saturating_sub(1);
+                if !this.delegate().can_reorder() || row_index >= last_index {
+                    return;
+                }
+                this.delegate_mut().reorder_servers(row_index, row_index + 1, cx);
+            }));
+
+        let item = ListItem::new(ix)
+            .p_1()
+            .child(
+                h_flex()
+                    .gap_1()
+                    .child(
+                        div()
+                            .child(Button::new(ix).success().icon(PandoraIcon::Play).on_click(move |_, window, cx| {
+                                root::start_instance(
+                                    id,
+                                    name.clone(),
+                                    Some(QuickPlayLaunch::Multiplayer(target.clone())),
+                                    &backend_handle,
+                                    window,
+                                    cx,
+                                );
+                            }))
+                            .px_2(),
+                    )
+                    .child(v_flex()
+                        .gap_1()
+                        .child(h_flex().gap_1().child(move_up).child(move_down))
+                        .px_1(),
+                    )
+                    .child(icon.size_16().min_w_16().min_h_16())
+                    .child(description),
+            );
 
         Some(item)
     }
@@ -417,8 +455,67 @@ impl ListDelegate for ServersListDelegate {
     }
 
     fn perform_search(&mut self, query: &str, _window: &mut Window, _cx: &mut Context<ListState<Self>>) -> Task<()> {
-        self.searched = self.servers.iter().filter(|w| w.name.contains(query)).cloned().collect();
+        self.search_query = query.to_string();
+        self.searched = self.apply_search(query);
 
         Task::ready(())
     }
+}
+
+impl ServersListDelegate {
+    fn can_reorder(&self) -> bool {
+        self.search_query.is_empty()
+    }
+
+    fn set_servers(&mut self, servers: Vec<InstanceServerSummary>) {
+        self.servers = servers;
+        self.searched = self.apply_search(&self.search_query);
+    }
+
+    fn apply_search(&self, query: &str) -> Vec<InstanceServerSummary> {
+        if query.is_empty() {
+            self.servers.clone()
+        } else {
+            self.servers.iter().filter(|w| w.name.contains(query)).cloned().collect()
+        }
+    }
+
+    fn reorder_servers(&mut self, from_index: usize, to_index: usize, cx: &mut Context<ListState<Self>>) {
+        if !self.can_reorder() {
+            return;
+        }
+
+        let Some(reordered) = reorder_vec(&self.servers, from_index, to_index) else {
+            return;
+        };
+
+        let reordered_arc: Arc<[InstanceServerSummary]> = reordered.clone().into();
+        self.servers = reordered;
+        self.searched = self.apply_search(&self.search_query);
+
+        let servers_entity = self.servers_entity.clone();
+        cx.update_entity(&servers_entity, |servers, cx| {
+            *servers = reordered_arc;
+            cx.notify();
+        });
+
+        self.backend_handle.send(MessageToBackend::ReorderServers {
+            id: self.id,
+            from_index,
+            to_index,
+        });
+        cx.notify();
+    }
+}
+
+fn reorder_vec<T: Clone>(items: &[T], from_index: usize, to_index: usize) -> Option<Vec<T>> {
+    if from_index >= items.len() || to_index >= items.len() || from_index == to_index {
+        return None;
+    }
+
+    let mut vec = items.to_vec();
+    let entry = vec.remove(from_index);
+    let insert_at = to_index.min(vec.len());
+    vec.insert(insert_at, entry);
+    Some(vec)
 }

--- a/crates/nbt/src/reference.rs
+++ b/crates/nbt/src/reference.rs
@@ -713,6 +713,21 @@ impl<'a> ListRefMut<'a> {
         self.get_self_node().1.len()
     }
 
+    pub fn move_index(&mut self, from: usize, to: usize) -> bool {
+        let (_, children) = self.get_self_node_mut();
+        if from >= children.len() || to >= children.len() || from == to {
+            return false;
+        }
+
+        let entry = children.remove(from);
+        let mut insert_at = to;
+        if insert_at > children.len() {
+            insert_at = children.len();
+        }
+        children.insert(insert_at, entry);
+        true
+    }
+
     pub fn get(&self, index: usize) -> Option<NBTRef<'_>> {
         let (_, children) = self.get_self_node();
         let idx = children.get(index)?;


### PR DESCRIPTION
Added up and down controls to reorder servers in instance quickplay list and persist the order back to the `servers.dat` so minecraft and the launcher stay in sync
Suppress refreshing from self-triggered file changes to avoid Icon Flicker

Edit: closes https://github.com/Moulberry/PandoraLauncher/issues/320