### PR TITLE
Implement sorting options for Modrinth and CurseForge

### DIFF
--- a/crates/backend/src/metadata/items.rs
+++ b/crates/backend/src/metadata/items.rs
@@ -513,7 +513,7 @@ impl<'a> MetadataItem for CurseforgeSearchMetadataItem<'a> {
     fn request(&self, client: &reqwest::Client) -> RequestBuilder {
         client.get(CURSEFORGE_SEARCH_URL)
             .query(self.0)
-            .query(&[("gameId", MINECRAFT_GAME_ID), ("sortField", 2)])
+            .query(&[("gameId", MINECRAFT_GAME_ID)])
             .query(&[("sortOrder", "desc")])
             .header("x-api-key", "$2a$10$YXf6dyJfJZM4zeChdr.RDOvWN.L48AN0dQShQO8/cVc5ho1wA8ZbS")
     }

--- a/crates/frontend/locales/locales.yml
+++ b/crates/frontend/locales/locales.yml
@@ -202,6 +202,18 @@ modrinth:
     512x+:
       en: 512x or higher
 
+  sort:
+    relevance:
+      en: Relevance
+    downloads:
+      en: Downloads
+    follows:
+      en: Follows
+    newest:
+      en: Newest
+    updated:
+      en: Updated
+
   environment:
     client_and_server:
       en: Client and server
@@ -226,6 +238,18 @@ modrinth:
 curseforge:
   name:
     en: Curseforge
+
+  sort:
+    popularity:
+      en: Popularity
+    downloads:
+      en: Downloads
+    updated:
+      en: Updated
+    name:
+      en: Name
+    author:
+      en: Author
 common:
   app_name:
     en: Pandora
@@ -545,6 +569,8 @@ instance:
         en: Discord
     categories:
       en: Categories
+    sort:
+      en: Sort by
     downloads:
       en: "%{num} Downloads"
     load:

--- a/crates/frontend/src/pages/curseforge_page.rs
+++ b/crates/frontend/src/pages/curseforge_page.rs
@@ -14,7 +14,7 @@ use ustr::Ustr;
 use crate::{
     component::error_alert::ErrorAlert, entity::{
         DataEntities, metadata::{AsMetadataResult, FrontendMetadata, FrontendMetadataResult}
-    }, icon::PandoraIcon, interface_config::InterfaceConfig, pages::page::Page, ts
+    }, icon::PandoraIcon, interface_config::InterfaceConfig, pages::page::Page, ts, ts_short
 };
 
 pub struct CurseforgeSearchPage {
@@ -852,7 +852,7 @@ impl Render for CurseforgeSearchPage {
                         .gap_1()
                         .child(
                             Button::new("toggle-sort")
-                                .label("Sort by")
+                                .label(ts!("instance.content.sort"))
                                 .icon(if is_sort_shown { PandoraIcon::ChevronDown } else { PandoraIcon::ChevronRight })
                                 .when(!is_sort_shown, |this| this.outline())
                                 .on_click(move |_, _, _| {
@@ -868,7 +868,8 @@ impl Render for CurseforgeSearchPage {
                                     Button::new(("sort", id))
                                         .child(
                                             h_flex().w_full().justify_start().gap_2()
-                                            .child(SharedString::new(field.clone().pretty_name())))
+                                            .child(
+                                                ts_short!(format!("curseforge.sort.{}", field.as_str()))))
                                         .selected(id == self.sort_field.clone() as u32)
                                 }))
                                 .on_click(cx.listener(move |page, clicked: &Vec<usize>, window, cx| {

--- a/crates/frontend/src/pages/curseforge_page.rs
+++ b/crates/frontend/src/pages/curseforge_page.rs
@@ -7,7 +7,8 @@ use gpui_component::{
     ActiveTheme, Selectable, WindowExt, button::{Button, ButtonGroup, ButtonVariant, ButtonVariants}, checkbox::Checkbox, h_flex, input::{Input, InputEvent, InputState}, notification::NotificationType, scroll::{ScrollableElement, Scrollbar}, skeleton::Skeleton, tooltip::Tooltip, v_flex
 };
 use rustc_hash::FxHashMap;
-use schema::{content::ContentSource, curseforge::{CurseforgeClassId, CurseforgeHit, CurseforgeSearchRequest, CurseforgeSearchResult}, loader::Loader};
+use schema::{content::ContentSource, curseforge::{CurseforgeClassId, CurseforgeHit, CurseforgeSearchRequest, CurseforgeSearchResult, CurseforgeSortField}, loader::Loader};
+use strum::IntoEnumIterator;
 use ustr::Ustr;
 
 use crate::{
@@ -30,7 +31,9 @@ pub struct CurseforgeSearchPage {
     _delayed_clear_task: Task<()>,
     filter_loaders: EnumSet<Loader>,
     filter_categories: BTreeSet<u32>,
+    sort_field: CurseforgeSortField,
     show_categories: Arc<AtomicBool>,
+    show_sort: Arc<AtomicBool>,
     can_install_latest: bool,
     installed_mods_by_project: FxHashMap<u32, Vec<InstalledMod>>,
     last_search: Arc<str>,
@@ -169,12 +172,14 @@ impl CurseforgeSearchPage {
             pending_reload: false,
             pending_clear: false,
             total_hits: 1,
+            sort_field: CurseforgeSortField::Popularity,
             search_state,
             _search_input_subscription,
             _delayed_clear_task: Task::ready(()),
             filter_loaders: Default::default(),
             filter_categories: Default::default(),
             show_categories: Arc::new(AtomicBool::new(false)),
+            show_sort: Arc::new(AtomicBool::new(false)),
             can_install_latest,
             installed_mods_by_project,
             last_search: Arc::from(""),
@@ -242,6 +247,14 @@ impl CurseforgeSearchPage {
             return;
         }
         self.filter_categories = categories;
+        self.reload(cx);
+    }
+
+    fn set_sort_field(&mut self, sort_field: CurseforgeSortField, _window: &mut Window, cx: &mut Context<Self>) {
+        if self.sort_field == sort_field {
+            return;
+        }
+        self.sort_field = sort_field;
         self.reload(cx);
     }
 
@@ -330,6 +343,7 @@ impl CurseforgeSearchPage {
             category_ids,
             game_version,
             mod_loader_types,
+            sort_field: self.sort_field.clone() as u32,
             index: offset as u32,
             page_size: 20
         };
@@ -795,7 +809,7 @@ impl Render for CurseforgeSearchPage {
             _ => &[],
         };
 
-        let is_shown = self.show_categories.load(std::sync::atomic::Ordering::Relaxed);
+        let is_category_shown = self.show_categories.load(std::sync::atomic::Ordering::Relaxed);
         let show_categories = self.show_categories.clone();
 
         let category = v_flex()
@@ -803,10 +817,10 @@ impl Render for CurseforgeSearchPage {
             .child(
                 Button::new("toggle-categories")
                     .label(ts!("instance.content.categories"))
-                    .icon(if is_shown { PandoraIcon::ChevronDown } else { PandoraIcon::ChevronRight })
-                    .when(!is_shown, |this| this.outline())
+                    .icon(if is_category_shown { PandoraIcon::ChevronDown } else { PandoraIcon::ChevronRight })
+                    .when(!is_category_shown, |this| this.outline())
                     .on_click(move |_, _, _| {
-                        show_categories.store(!is_shown, std::sync::atomic::Ordering::Relaxed);
+                        show_categories.store(!is_category_shown, std::sync::atomic::Ordering::Relaxed);
                     })
             )
             .child(
@@ -826,9 +840,44 @@ impl Render for CurseforgeSearchPage {
                             .filter_map(|index| categories.get(*index).map(|(_, id)| *id))
                             .collect(), window, cx);
                     }))
-                    .when(!is_shown, |this| this.invisible().h_0())
+                    .when(!is_category_shown, |this| this.invisible().h_0())
             )
             .into_any_element();
+
+        let sort_fields = CurseforgeSortField::iter().collect::<Vec<_>>();
+        let is_sort_shown = self.show_sort.load(std::sync::atomic::Ordering::Relaxed);
+        let show_sort = self.show_sort.clone();
+
+        let sort = v_flex()
+                        .gap_1()
+                        .child(
+                            Button::new("toggle-sort")
+                                .label("Sort by")
+                                .icon(if is_sort_shown { PandoraIcon::ChevronDown } else { PandoraIcon::ChevronRight })
+                                .when(!is_sort_shown, |this| this.outline())
+                                .on_click(move |_, _, _| {
+                                    show_sort.store(!is_sort_shown, std::sync::atomic::Ordering::Relaxed);
+                                })
+                        )
+                        .child(
+                            ButtonGroup::new("sort_field")
+                                .layout(Axis::Vertical)
+                                .outline()
+                                .children(sort_fields.iter().map(|field| {
+                                    let id = field.clone() as u32;
+                                    Button::new(("sort", id))
+                                        .child(
+                                            h_flex().w_full().justify_start().gap_2()
+                                            .child(SharedString::new(field.clone().pretty_name())))
+                                        .selected(id == self.sort_field.clone() as u32)
+                                }))
+                                .on_click(cx.listener(move |page, clicked: &Vec<usize>, window, cx| {
+                                    let sort_field = sort_fields.get(clicked[0]).cloned().unwrap_or(CurseforgeSortField::Popularity);
+                                    page.set_sort_field(sort_field, window, cx);
+                                }))
+                                .when(!is_sort_shown, |this| this.invisible().h_0())
+                        )
+                        .into_any_element();
 
         let is_mod = filter_project_type == CurseforgeClassId::Mod || filter_project_type == CurseforgeClassId::Modpack;
         let filter_version_toggle = if is_mod && let Some(filter_version) = self.filter_version {
@@ -855,7 +904,8 @@ impl Render for CurseforgeSearchPage {
             .child(type_button_group)
             .when_some(loader_button_group, |this, group| this.child(group))
             .when_some(filter_version_toggle, |this, button| this.child(button))
-            .child(category);
+            .child(category)
+            .child(sort);
 
         h_flex().flex_1().min_h_0().size_full().child(parameters).child(content)
     }

--- a/crates/frontend/src/pages/modrinth_page.rs
+++ b/crates/frontend/src/pages/modrinth_page.rs
@@ -257,7 +257,6 @@ impl ModrinthSearchPage {
     }
 
     fn set_sort_option(&mut self, sort_option: ModrinthSearchIndex, _window: &mut Window, cx: &mut Context<Self>) {
-        println!("Setting sort to {}", sort_option.pretty_name());
         if self.sort_option == sort_option {
             return;
         }
@@ -928,7 +927,7 @@ impl Render for ModrinthSearchPage {
             .gap_1()
             .child(
                 Button::new("toggle-sort")
-                    .label("Sort by")
+                    .label(ts!("instance.content.sort"))
                     .icon(if is_sort_shown { PandoraIcon::ChevronDown } else { PandoraIcon::ChevronRight })
                     .when(!is_sort_shown, |this| this.outline())
                     .on_click(move |_, _, _| {
@@ -940,8 +939,9 @@ impl Render for ModrinthSearchPage {
                     .layout(Axis::Vertical)
                     .outline()
                     .children(sort_options.iter().map(|search_index| {
-                        Button::new(search_index.pretty_name())
-                            .child(h_flex().w_full().justify_start().gap_2().child(search_index.pretty_name()))
+                        Button::new(search_index.as_str())
+                            .child(h_flex().w_full().justify_start().gap_2()
+                                .child(ts_short!(format!("modrinth.sort.{}", search_index.as_str()))))
                             .selected(*search_index == self.sort_option)
                     }))
                     .on_click(cx.listener(move |page, clicked: &Vec<usize>, window, cx| {

--- a/crates/frontend/src/pages/modrinth_page.rs
+++ b/crates/frontend/src/pages/modrinth_page.rs
@@ -8,9 +8,10 @@ use gpui_component::{
 };
 use rustc_hash::FxHashMap;
 use schema::{content::ContentSource, loader::Loader, modrinth::{
-    ModrinthHit, ModrinthProjectType, ModrinthSearchRequest, ModrinthSearchResult, ModrinthSideRequirement
+    ModrinthHit, ModrinthProjectType, ModrinthSearchIndex, ModrinthSearchRequest, ModrinthSearchResult, ModrinthSideRequirement
 }};
 use ustr::Ustr;
+use strum::IntoEnumIterator;
 
 use crate::{
     component::error_alert::ErrorAlert, entity::{
@@ -32,7 +33,9 @@ pub struct ModrinthSearchPage {
     _delayed_clear_task: Task<()>,
     filter_loaders: EnumSet<Loader>,
     filter_categories: BTreeSet<&'static str>,
+    sort_option: ModrinthSearchIndex,
     show_categories: Arc<AtomicBool>,
+    show_sort_options: Arc<AtomicBool>,
     can_install_latest: bool,
     installed_mods_by_project: FxHashMap<Arc<str>, Vec<InstalledMod>>,
     last_search: Arc<str>,
@@ -180,7 +183,9 @@ impl ModrinthSearchPage {
             _delayed_clear_task: Task::ready(()),
             filter_loaders: Default::default(),
             filter_categories: Default::default(),
+            sort_option: ModrinthSearchIndex::Relevance,
             show_categories: Arc::new(AtomicBool::new(false)),
+            show_sort_options: Arc::new(AtomicBool::new(false)),
             can_install_latest,
             installed_mods_by_project,
             last_search: Arc::from(""),
@@ -248,6 +253,15 @@ impl ModrinthSearchPage {
             return;
         }
         self.filter_categories = categories;
+        self.reload(cx);
+    }
+
+    fn set_sort_option(&mut self, sort_option: ModrinthSearchIndex, _window: &mut Window, cx: &mut Context<Self>) {
+        println!("Setting sort to {}", sort_option.pretty_name());
+        if self.sort_option == sort_option {
+            return;
+        }
+        self.sort_option = sort_option;
         self.reload(cx);
     }
 
@@ -349,7 +363,7 @@ impl ModrinthSearchPage {
         let request = ModrinthSearchRequest {
             query,
             facets: Some(facets.into()),
-            index: schema::modrinth::ModrinthSearchIndex::Relevance,
+            index: self.sort_option.clone(),
             offset,
             limit: 20,
         };
@@ -868,7 +882,7 @@ impl Render for ModrinthSearchPage {
             ModrinthProjectType::Other => &[],
         };
 
-        let is_shown = self.show_categories.load(std::sync::atomic::Ordering::Relaxed);
+        let is_category_shown = self.show_categories.load(std::sync::atomic::Ordering::Relaxed);
         let show_categories = self.show_categories.clone();
 
         let category = v_flex()
@@ -876,10 +890,10 @@ impl Render for ModrinthSearchPage {
             .child(
                 Button::new("toggle-categories")
                     .label(ts!("instance.content.categories"))
-                    .icon(if is_shown { PandoraIcon::ChevronDown } else { PandoraIcon::ChevronRight })
-                    .when(!is_shown, |this| this.outline())
+                    .icon(if is_category_shown { PandoraIcon::ChevronDown } else { PandoraIcon::ChevronRight })
+                    .when(!is_category_shown, |this| this.outline())
                     .on_click(move |_, _, _| {
-                        show_categories.store(!is_shown, std::sync::atomic::Ordering::Relaxed);
+                        show_categories.store(!is_category_shown, std::sync::atomic::Ordering::Relaxed);
                     })
             )
             .child(
@@ -902,9 +916,42 @@ impl Render for ModrinthSearchPage {
                             .filter_map(|index| categories.get(*index).map(|s| *s))
                             .collect(), window, cx);
                     }))
-                    .when(!is_shown, |this| this.invisible().h_0())
+                    .when(!is_category_shown, |this| this.invisible().h_0())
             )
             .into_any_element();
+
+        let sort_options = ModrinthSearchIndex::iter().collect::<Vec<_>>();
+        let is_sort_shown = self.show_sort_options.load(std::sync::atomic::Ordering::Relaxed);
+        let show_sort_options = self.show_sort_options.clone();
+
+        let sort = v_flex()
+            .gap_1()
+            .child(
+                Button::new("toggle-sort")
+                    .label("Sort by")
+                    .icon(if is_sort_shown { PandoraIcon::ChevronDown } else { PandoraIcon::ChevronRight })
+                    .when(!is_sort_shown, |this| this.outline())
+                    .on_click(move |_, _, _| {
+                        show_sort_options.store(!is_sort_shown, std::sync::atomic::Ordering::Relaxed);
+                    })
+            )
+            .child(
+                ButtonGroup::new("sort_group")
+                    .layout(Axis::Vertical)
+                    .outline()
+                    .children(sort_options.iter().map(|search_index| {
+                        Button::new(search_index.pretty_name())
+                            .child(h_flex().w_full().justify_start().gap_2().child(search_index.pretty_name()))
+                            .selected(*search_index == self.sort_option)
+                    }))
+                    .on_click(cx.listener(move |page, clicked: &Vec<usize>, window, cx| {
+                        let sort_option = sort_options.get(clicked[0]).cloned().unwrap_or(ModrinthSearchIndex::Relevance);
+                        page.set_sort_option(sort_option, window, cx);
+                    }))
+                    .when(!is_sort_shown, |this| this.invisible().h_0())
+            )
+            .into_any_element();
+
 
         let is_mod = filter_project_type == ModrinthProjectType::Mod || filter_project_type == ModrinthProjectType::Modpack;
         let filter_version_toggle = if is_mod && let Some(filter_version) = self.filter_version {
@@ -931,7 +978,8 @@ impl Render for ModrinthSearchPage {
             .child(type_button_group)
             .when_some(loader_button_group, |this, group| this.child(group))
             .when_some(filter_version_toggle, |this, button| this.child(button))
-            .child(category);
+            .child(category)
+            .child(sort);
 
         h_flex().flex_1().min_h_0().size_full().child(parameters).child(content)
     }

--- a/crates/schema/src/curseforge.rs
+++ b/crates/schema/src/curseforge.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
+use strum::EnumIter;
 use ustr::Ustr;
 
 use crate::loader::Loader;
@@ -20,6 +21,7 @@ pub struct CurseforgeSearchRequest {
     pub search_filter: Option<Arc<str>>,
     #[serde(skip_serializing_if = "crate::skip_if_none")]
     pub mod_loader_types: Option<Arc<str>>,
+    pub sort_field: u32,
     pub index: u32,
     pub page_size: u32,
 }
@@ -210,6 +212,27 @@ impl CurseforgeModLoaderType {
     }
 }
 
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, EnumIter)]
+#[repr(u32)]
+pub enum CurseforgeSortField {
+    Popularity = 2,
+    Downloads = 6,
+    LastUpdated = 3,
+    Name = 4,
+    Author = 5,
+}
+
+impl CurseforgeSortField {
+    pub fn pretty_name(self) -> &'static str {
+        match self {
+            Self::Popularity => "Popularity",
+            Self::Downloads => "Downloads",
+            Self::LastUpdated => "Updated",
+            Self::Name => "Name",
+            Self::Author => "Author",
+        }
+    }
+}
 
 #[derive(Default, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, Debug)]
 #[serde(rename_all = "lowercase")]

--- a/crates/schema/src/curseforge.rs
+++ b/crates/schema/src/curseforge.rs
@@ -223,13 +223,13 @@ pub enum CurseforgeSortField {
 }
 
 impl CurseforgeSortField {
-    pub fn pretty_name(self) -> &'static str {
+    pub fn as_str(&self) -> &'static str {
         match self {
-            Self::Popularity => "Popularity",
-            Self::Downloads => "Downloads",
-            Self::LastUpdated => "Updated",
-            Self::Name => "Name",
-            Self::Author => "Author",
+            Self::Popularity => "popularity",
+            Self::Downloads => "downloads",
+            Self::LastUpdated => "updated",
+            Self::Name => "name",
+            Self::Author => "author",
         }
     }
 }

--- a/crates/schema/src/modrinth.rs
+++ b/crates/schema/src/modrinth.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
+use strum::EnumIter;
 use ustr::Ustr;
 
 pub const MODRINTH_SEARCH_URL: &str = "https://api.modrinth.com/v2/search";
@@ -21,7 +22,7 @@ pub struct ModrinthProjectVersionsRequest {
     pub loaders: Option<Arc<[ModrinthLoader]>>,
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, EnumIter)]
 #[serde(rename_all = "lowercase")]
 pub enum ModrinthSearchIndex {
     Relevance,
@@ -29,6 +30,18 @@ pub enum ModrinthSearchIndex {
     Follows,
     Newest,
     Updated,
+}
+
+impl ModrinthSearchIndex {
+    pub fn pretty_name(&self) -> &'static str {
+        match self {
+            ModrinthSearchIndex::Relevance => "Relevance",
+            ModrinthSearchIndex::Downloads => "Downloads",
+            ModrinthSearchIndex::Follows => "Follows",
+            ModrinthSearchIndex::Newest => "Newest",
+            ModrinthSearchIndex::Updated => "Updated",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/schema/src/modrinth.rs
+++ b/crates/schema/src/modrinth.rs
@@ -33,13 +33,13 @@ pub enum ModrinthSearchIndex {
 }
 
 impl ModrinthSearchIndex {
-    pub fn pretty_name(&self) -> &'static str {
+    pub fn as_str(&self) -> &'static str {
         match self {
-            ModrinthSearchIndex::Relevance => "Relevance",
-            ModrinthSearchIndex::Downloads => "Downloads",
-            ModrinthSearchIndex::Follows => "Follows",
-            ModrinthSearchIndex::Newest => "Newest",
-            ModrinthSearchIndex::Updated => "Updated",
+            ModrinthSearchIndex::Relevance => "relevance",
+            ModrinthSearchIndex::Downloads => "downloads",
+            ModrinthSearchIndex::Follows => "follows",
+            ModrinthSearchIndex::Newest => "newest",
+            ModrinthSearchIndex::Updated => "updated",
         }
     }
 }


### PR DESCRIPTION
Adds a "sort by" dropdown below categories that provides different fields to sort by. Supports all Modrinth sorting options and some CurseForge ones (they have 12, so I just included the ones that Prism uses, excluding Featured).

Closes #54