### PR TITLE
[Feature] MacOS Microphone Permission

### DIFF
--- a/package/mac/Info.plist
+++ b/package/mac/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>A Minecraft mod wants to access your microphone.</string>
+</dict>
+</plist>

--- a/package/mac/entitlements.plist
+++ b/package/mac/entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+</dict>
+</plist>

--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -31,7 +31,7 @@ env -u CARGO_PACKAGER_SIGN_PRIVATE_KEY cargo packager --config '{'\
 '  "authors": ["Moulberry"],'\
 '  "binaries": [{ "path": "PandoraLauncher-macOS-Universal", "main": true }],'\
 '  "icons": ["package/mac.icns"],'\
-'  "macos: {"entitlements": "package/mac/entitlements.plist", "infoPlistPath": "package/mac/Info.plist"}' \
+'  "macos": {"entitlements": "package/mac/entitlements.plist", "infoPlistPath": "package/mac/Info.plist"}'\
 '}'
 
 mv -f dist/PandoraLauncher-macOS-Universal dist/PandoraLauncher-macOS-Universal-Portable

--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -31,6 +31,7 @@ env -u CARGO_PACKAGER_SIGN_PRIVATE_KEY cargo packager --config '{'\
 '  "authors": ["Moulberry"],'\
 '  "binaries": [{ "path": "PandoraLauncher-macOS-Universal", "main": true }],'\
 '  "icons": ["package/mac.icns"]'\
+'  "macos: {"entitlements": "package/mac/entitlements.plist", "infoPlistPath": "package/mac/Info.plist"}' \
 '}'
 
 mv -f dist/PandoraLauncher-macOS-Universal dist/PandoraLauncher-macOS-Universal-Portable

--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -30,7 +30,7 @@ env -u CARGO_PACKAGER_SIGN_PRIVATE_KEY cargo packager --config '{'\
 '  "resources": [],'\
 '  "authors": ["Moulberry"],'\
 '  "binaries": [{ "path": "PandoraLauncher-macOS-Universal", "main": true }],'\
-'  "icons": ["package/mac.icns"]'\
+'  "icons": ["package/mac.icns"],'\
 '  "macos: {"entitlements": "package/mac/entitlements.plist", "infoPlistPath": "package/mac/Info.plist"}' \
 '}'
 


### PR DESCRIPTION
This PR adds an Info.plist and entitlements.plist to add the required `NSMicrophoneUsageDescription` and entitlement for microphone access.


Locally this works for me _after_ I self sign  `PandoraLauncher.app` with my own developer account.
Without signing the app MacOS asks for the permission repeatably before stopping; the microphone does work, though. 

On line 40 of build_mac.sh you delete the app after archiving it.
I believe you might need to sign it first:
```sh
if [[ -n "$CARGO_PACKAGER_SIGN_PRIVATE_KEY" ]]; then
    cargo packager signer sign dist/PandoraLauncher.app
fi
```
The signature for the app seems to be (as of the last release) adhoc. With that configuration the feature didn't seem to work. 
Before this feature could work there may need to be changes to the build process to include a developer signature.
Is there a specific reason why you unset the signature when building? Does cargo-packager not handle signing the way you like by default?