### PR TITLE
fix: silent failure when installing content across different partitions

### DIFF
--- a/crates/backend/src/backend.rs
+++ b/crates/backend/src/backend.rs
@@ -992,7 +992,9 @@ impl BackendState {
                     } else if let Some(filename) = dest_path.file_name() {
                         let filename = format!(".pandora.{filename}");
                         let hidden_dest_path = mod_dir.join(filename);
-                        let _ = std::fs::hard_link(path, hidden_dest_path);
+                        if let Err(err) = crate::hard_link_or_copy(&path, &hidden_dest_path) {
+                            log::error!("Failed to install modpack mod to {:?}: {err}", hidden_dest_path);
+                        }
                     }
                 } else {
                     let dest_path = dest_path.to_path(&dot_minecraft_path);
@@ -1034,7 +1036,9 @@ impl BackendState {
                         } else if let Some(filename) = rel_path.file_name() {
                             let filename = format!(".pandora.{filename}");
                             let hidden_dest_path = mod_dir.join(filename);
-                            let _ = std::fs::hard_link(path, hidden_dest_path);
+                            if let Err(err) = crate::hard_link_or_copy(&path, &hidden_dest_path) {
+                                log::error!("Failed to install modpack override mod to {:?}: {err}", hidden_dest_path);
+                            }
                         }
                     } else {
                         let dest_path = rel_path.to_path(&dot_minecraft_path);

--- a/crates/backend/src/install_content.rs
+++ b/crates/backend/src/install_content.rs
@@ -243,11 +243,22 @@ impl BackendState {
 
                 let _ = std::fs::create_dir_all(target_path.parent().unwrap());
 
-                if let Some(replace) = install.replace {
-                    self.replace_aux_path(&replace, &install.mod_summary, &target_path);
-                    let _ = std::fs::remove_file(replace);
+                match crate::hard_link_or_copy(&install.from, &target_path) {
+                    Ok(()) => {
+                        if let Some(replace) = install.replace {
+                            self.replace_aux_path(&replace, &install.mod_summary, &target_path);
+                            let replace_path: &Path = &replace;
+                            if replace_path != target_path.as_path() {
+                                let _ = std::fs::remove_file(&replace);
+                            }
+                        }
+                    },
+                    Err(err) => {
+                        log::error!("Failed to install content to {:?}: {err}", target_path);
+                        let message = format!("Failed to install content to {}: {err}", target_path.display());
+                        modal_action.set_error_message(Arc::from(message.as_str()));
+                    },
                 }
-                let _ = std::fs::hard_link(install.from, target_path);
             }
         }
     }

--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -337,6 +337,19 @@ pub fn symlink_dir_or_file(original: &Path, link: &Path) -> std::io::Result<()> 
     compile_error!("Unsupported platform: can't symlink");
 }
 
+pub fn hard_link_or_copy(from: &Path, to: &Path) -> std::io::Result<()> {
+    match std::fs::remove_file(to) {
+        Ok(()) => {},
+        Err(err) if err.kind() == ErrorKind::NotFound => {},
+        Err(err) => return Err(err),
+    }
+    if std::fs::hard_link(from, to).is_ok() {
+        return Ok(());
+    }
+    log::trace!("hard_link failed for {:?} -> {:?}, falling back to copy", from, to);
+    std::fs::copy(from, to).map(|_| ())
+}
+
 pub fn rename_with_fallback_across_devices(from: &Path, to: &Path) -> std::io::Result<()> {
     // Remove empty 'to' directory to ensure consistent behaviour across unix and windows
     if let Err(err) = std::fs::remove_dir(to) && !matches!(err.kind(), ErrorKind::NotADirectory | ErrorKind::NotFound) {


### PR DESCRIPTION
In the current implementation, std::fs::hard_link silently faills across volumes (in windows terms) when installing content.

I got ERROR_NOT_SAME_DEVICE when trying to update a modpack because the content library is stored on the C drive (appdata) and i moved the instance to a separate volume (X: drive). This resulted in the old file being deleted before the link attempt so both the old and new files vanish.

The proposed fix implements hard_link_or_copy which determins if a file copy should be made as a fallback in case the content lib isnt on the same volume- but still prefers the hard_link. Yes this is a bandaid and the proper fix would be to expose the content library path but that raises its own set of problems (mostly the data migration and the way it should be handled) so i leave that up to your sanction.