### PR TITLE
fix silent instance loading skip if file found in directory

### DIFF
--- a/crates/backend/src/backend.rs
+++ b/crates/backend/src/backend.rs
@@ -265,7 +265,7 @@ impl BackendState {
             let mut time = SystemTime::UNIX_EPOCH;
             if let Ok(metadata) = entry.metadata() {
                 if metadata.is_file() {
-                    return;
+                    continue;
                 }
                 if let Ok(created) = metadata.created() {
                     time = time.max(created);


### PR DESCRIPTION
fixes a bug where having any file in your instances directory could cause some instances to fail to load, since `BackendState::load_all_instances` would return early after hitting a file. i assume returning here was just a typo, but if there's some deeper reason i missed just ignore this.