### PR TITLE
Add Swedish translations

### DIFF
--- a/crates/t/build.rs
+++ b/crates/t/build.rs
@@ -3,7 +3,7 @@ use std::{error::Error, path::Path};
 use indexmap::IndexMap;
 
 fn main() {
-    println!("cargo:rerun-if-changed=./locales.yml");
+    println!("cargo:rerun-if-changed=./locales.toml");
     println!("cargo:rerun-if-changed=build.rs");
 
     let dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
@@ -52,6 +52,8 @@ fn inner(dir: &Path) -> Result<(), Box<dyn Error>> {
         locales.nodes[*root].write(&locales, 0, &mut content);
     }
 
+    // maybe we could instead write it to OUT_DIR and use include! in lib.rs
+    // this would have the benefit of not polluting git history
     let lib = dir.join("src").join("lib.rs");
     std::fs::write(&lib, content.as_bytes())?;
     Ok(())
@@ -69,6 +71,8 @@ impl LocaleNode {
     pub fn write(&self, locales: &Locales, indentation: usize, content: &mut String) {
         match &self.val {
             LocaleNodeVal::Parent { children, static_translation_children } => {
+                content.push_str(&INDENTATION[..indentation*4]);
+                content.push_str("#[rustfmt::skip]\n");
                 content.push_str(&INDENTATION[..indentation*4]);
                 content.push_str("pub mod ");
                 content.push_str(&self.name);
@@ -311,7 +315,7 @@ impl Locales {
                                     for existing in &arguments {
                                         if existing.0 == name {
                                             if existing.1 != ty {
-                                                return Err(format!("Multiple arguments with different types: {}", existing.0).into());
+                                                return Err(format!("Multiple arguments with different types: {} in {}", existing.0, value).into());
                                             }
                                             has_existing = true;
                                         }

--- a/crates/t/locales.toml
+++ b/crates/t/locales.toml
@@ -2,143 +2,178 @@
 en = "Modrinth"
 de = "Modrinth"
 hu = "Modrinth"
+sv = "Modrinth"
 
 [modrinth.category.fabric]
 en = "Fabric"
 de = "Fabric"
 hu = "Fabric"
+sv = "Fabric"
 [modrinth.category.forge]
 en = "Forge"
 de = "Forge"
 hu = "Forge"
+sv = "Forge"
 [modrinth.category.neoforge]
 en = "NeoForge"
 de = "NeoForge"
 hu = "NeoForge"
+sv = "NeoForge"
 [modrinth.category.quilt]
 en = "Quilt"
 de = "Quilt"
 hu = "Quilt"
+sv = "Quilt"
 [modrinth.category.babric]
 en = "Babric"
 de = "Babric"
 hu = "Babric"
+sv = "Babric"
 [modrinth.category.bta-babric]
 en = "BTA (Babric)"
 de = "BTA (Babric)"
 hu = "BTA (Babric)"
+sv = "BTA (Babric)"
 [modrinth.category.java-agent]
 en = "Java Agent"
 de = "Java Agent"
 hu = "Java Agent"
+sv = "Java Agent"
 [modrinth.category.legacy-fabric]
 en = "Legacy Fabric"
 de = "Legacy Fabric"
 hu = "Legacy Fabric"
+sv = "Legacy Fabric"
 [modrinth.category.liteloader]
 en = "LiteLoader"
 de = "LiteLoader"
 hu = "LiteLoader"
+sv = "LiteLoader"
 [modrinth.category.modloader]
 en = "Risugami's ModLoader"
 de = "Risugami's ModLoader"
 hu = "Risumagi's ModLoader"
+sv = "Risumagi's ModLoader"
 [modrinth.category.nilloader]
 en = "NilLoader"
 de = "NilLoader"
 hu = "NilLoader"
+sv = "NilLoader"
 [modrinth.category.ornithe]
 en = "Ornithe"
 de = "Ornithe"
 hu = "Ornithe"
+sv = "Ornithe"
 [modrinth.category.rift]
 en = "Rift"
 de = "Rift"
 hu = "Rift"
+sv = "Rift"
 [modrinth.category.datapack]
 en = "Data Pack"
 de = "Data Pack"
 hu = "Adatcsomag"
+sv = "Data Pack"
 [modrinth.category.iris]
 en = "Iris"
 de = "Iris"
 hu = "Iris"
+sv = "Iris"
 [modrinth.category.optifine]
 en = "OptiFine"
 de = "OptiFine"
 hu = "OptiFine"
+sv = "OptiFine"
 [modrinth.category.canvas]
 en = "Canvas"
 de = "Canvas"
 hu = "Canvas"
+sv = "Canvas"
 [modrinth.category.vanilla]
 en = "Vanilla Shader"
 de = "Vanilla Shader"
 hu = "Vanilla Shader"
+sv = "Vanilla Shader"
 [modrinth.category.bukkit]
 en = "Bukkit"
 de = "Bukkit"
 hu = "Bukkit"
+sv = "Bukkit"
 [modrinth.category.folia]
 en = "Folia"
 de = "Folia"
 hu = "Folia"
+sv = "Folia"
 [modrinth.category.paper]
 en = "Paper"
 de = "Paper"
 hu = "Paper"
+sv = "Paper"
 [modrinth.category.purpur]
 en = "Purpur"
 de = "Purpur"
 hu = "Purpur"
+sv = "Purpur"
 [modrinth.category.spigot]
 en = "Spigot"
 de = "Spigot"
 hu = "Spigot"
+sv = "Spigot"
 [modrinth.category.sponge]
 en = "Sponge"
 de = "Sponge"
 hu = "Sponge"
+sv = "Sponge"
 [modrinth.category.bungeecord]
 en = "BungeeCord"
 de = "BungeeCord"
 hu = "BungeeCord"
+sv = "BungeeCord"
 [modrinth.category.geyser]
 en = "Geyser"
 de = "Geyser"
 hu = "Geyser"
+sv = "Geyser"
 [modrinth.category.velocity]
 en = "Velocity"
 de = "Velocity"
 hu = "Velocity"
+sv = "Velocity"
 [modrinth.category.waterfall]
 en = "Waterfall"
 de = "Waterfall"
 hu = "Waterfall"
+sv = "Waterfall"
 [modrinth.category.cursed]
 en = "Cursed"
 de = "Seltsam"
 hu = "Átkozott"
+sv = "Förbannad"
 [modrinth.category.technology]
 en = "Technology"
 de = "Technologie"
 hu = "Technológia"
+sv = "Teknologi"
 [modrinth.category.challenging]
 en = "Challenging"
 de = "Herausforderend"
 hu = "Kihívó"
+sv = "Utmaning"
 [modrinth.category.decoration]
 en = "Decoration"
 de = "Dekoration"
 hu = "Dekoráció"
+sv = "Dekoration"
 [modrinth.category.library]
 en = "Library"
 de = "Bibiliothek"
 hu = "Könyvtár"
+sv = "Bibliotek"
 [modrinth.category.adventure]
 en = "Adventure"
 de = "Abenteuer"
 hu = "Kaland"
+sv = "Äventyr"
 [modrinth.category.path-tracing]
 en = "Path Tracing"
 de = "Path Tracing"
@@ -147,154 +182,192 @@ hu = "Path Tracing"
 en = "Realistic"
 de = "Realistisch"
 hu = "Realisztikus"
+sv = "realistiskt"
 [modrinth.category.atmosphere]
 en = "Atmosphere"
 de = "Atmosphere"
 hu = "Atmoszféra"
+sv = "atmosfär"
 [modrinth.category.fantasy]
 en = "Fantasy"
 de = "Fantasie"
 hu = "Fantázia"
+sv = "Fantasi"
 [modrinth.category.foliage]
 en = "Foliage"
 de = "Vegetation"
 hu = "Növényzet"
+sv = "Vegetation"
 [modrinth.category.bloom]
 en = "Bloom"
 de = "Bloom"
 hu = "Bloom"
+sv = "Bloom"
 [modrinth.category.vanilla-like]
 en = "Vanilla-like"
 de = "Vanilla-Ähnlich"
 hu = "Vanilla-szerű"
+sv = "Vanilla liknande"
 [modrinth.category.cartoon]
 en = "Cartoon"
 de = "Cartoon"
 hu = "Rajzfilmes"
+sv = "Teknad"
 [modrinth.category.shadows]
 en = "Shadows"
 de = "Schatten"
 hu = "Árnyékok"
+sv = "Skuggor"
 [modrinth.category.pbr]
 en = "PBR"
 de = "PBR"
 hu = "PBR"
+sv = "PBR"
 [modrinth.category.semi-realistic]
 en = "Semi-realistic"
 de = "Semi-Realistisch"
 hu = "Félig valósághű"
+sv = "Semi realistiskt"
 [modrinth.category.reflections]
 en = "Reflections"
 de = "Reflektionen"
 hu = "Tükröződések"
+sv = "Reflektioner"
 [modrinth.category.colored-lighting]
 en = "Colored Lighting"
 de = "Farbige Lichter"
 hu = "Színes világítás"
+sv = "Färgat Ljus"
 [modrinth.category.economy]
 en = "Economy"
 de = "Wirtschaft"
 hu = "Gazdaság"
+sv = "Ekonomi"
 [modrinth.category.management]
 en = "Management"
 de = "Verwaltung"
 hu = "Kezelés"
+sv = "Förvaltning"
 [modrinth.category.optimization]
 en = "Optimization"
 de = "Optimierung"
 hu = "Optimalizálás"
+sv = "Optimisation"
 [modrinth.category.mobs]
 en = "Mobs"
 de = "Mobs"
 hu = "Mobok"
+sv = "Mobs"
 [modrinth.category.transportation]
 en = "Transportation"
 de = "Transportation"
 hu = "Szállítás"
+sv = "Transportation"
 [modrinth.category.kitchen-sink]
 en = "Kitchen sink"
 de = "Etwas von allem"
 hu = "Mindenből egy kicsi"
+sv = "Allt möjligt"
 [modrinth.category.blocks]
 en = "Blocks"
 de = "Blöcke"
 hu = "Blokkok"
+sv = "Blocks"
 [modrinth.category.audio]
 en = "Audio"
 de = "Audio"
 hu = "Hang"
+sv = "Ljud"
 [modrinth.category.combat]
 en = "Combat"
 de = "Kampf"
 hu = "Harc"
+sv = "Strid"
 [modrinth.category.modded]
 en = "Modded"
 de = "Modifiziert"
 hu = "Modolt"
+sv = "Moddat"
 [modrinth.category.environment]
 en = "Environment"
 de = "Umgebung"
 hu = "Környezet"
+sv = "Miljö"
 [modrinth.category.entities]
 en = "Entities"
 de = "Entitäten"
 hu = "Entitások"
+sv = "Entiteter"
 [modrinth.category.game-mechanics]
 en = "Game Mechanics"
 de = "Spielmechaniken"
 hu = "Játék mechanikák"
+sv = "Spelmekaniker"
 [modrinth.category.utility]
 en = "Utility"
 de = "Nützlich"
 hu = "Hasznos"
+sv = "Vertyg"
 [modrinth.category.core-shaders]
 en = "Core Shaders"
 de = "Core-Shaders"
 hu = "Alap shaderek"
+sv = "Core-shaders"
 [modrinth.category.tweaks]
 en = "Tweaks"
 de = "Optimierungen"
 hu = "Finomítások"
+sv = "Justeringar"
 [modrinth.category.items]
 en = "Items"
 de = "Gegenstände"
 hu = "Tárgyak"
+sv = "Items"
 [modrinth.category.models]
 en = "Models"
 de = "Modelle"
 hu = "Modellek"
+sv = "Modeller"
 [modrinth.category.equipment]
 en = "Equipment"
 de = "Ausrüstung"
 hu = "Felszerelés"
+sv = "Utrustning"
 [modrinth.category.fonts]
 en = "Fonts"
 de = "Schriftarten"
 hu = "Betűtípusok"
+sv = "Fonter"
 [modrinth.category.simplistic]
 en = "Simplistic"
 de = "Einfach"
 hu = "Egyszerű"
+sv = "Simplistiskt"
 [modrinth.category.themed]
 en = "Themed"
 de = "Thematisch"
 hu = "Tematikus"
+sv = "Temat"
 [modrinth.category.magic]
 en = "Magic"
 de = "Magie"
 hu = "Mágia"
+sv = "Magi"
 [modrinth.category.storage]
 en = "Storage"
 de = "Lagerung"
 hu = "Tárhely"
+sv = "Utrustning"
 [modrinth.category.food]
 en = "Food"
 de = "Essen"
 hu = "Étel"
+sv = "Mat"
 [modrinth.category.gui]
 en = "GUI"
 de = "GUI"
 hu = "GUI"
+sv = "GUI"
 [modrinth.category.worldgen]
 en = "World Generation"
 en_short = "Worldgen"
@@ -302,1009 +375,1267 @@ de = "Weltgenerierung"
 de_short = "Weltgenerierung"
 hu = "Világgenerálás"
 hu_short = "Generálás"
+sv = "Världsgeneration"
+sv_short = "Generering"
 [modrinth.category.multiplayer]
 en = "Multiplayer"
 de = "Mehrspieler"
 hu = "Többjátékos"
+sv = "Flerspelare"
 [modrinth.category.quests]
 en = "Quests"
 de = "Aufgaben"
 hu = "Küldetések"
+sv = "Uppdrag"
 [modrinth.category.lightweight]
 en = "Lightweight"
 de = "Leichtgewichtig"
 hu = "Könnyű"
+sv = "Lätt"
 [modrinth.category.social]
 en = "Social"
 de = "Sozial"
 hu = "Szociális"
+sv = "Social"
 [modrinth.category.minigame]
 en = "Minigame"
 de = "Minispiel"
 hu = "Minijáték"
+sv = "Minispel"
 [modrinth.category.locale]
 en = "Locale"
 de = "Lokalisierung"
 hu = "Nyelv"
+sv = "Lokalisering"
 [modrinth.category.potato]
 en = "Potato"
 de = "Kartoffel"
 hu = "Krumpli"
+sv = "Potatis"
 [modrinth.category.low]
 en = "Low"
 de = "Niedrig"
 hu = "Alacsony"
+sv = "Låg"
 [modrinth.category.medium]
 en = "Medium"
 de = "Mittel"
 hu = "Közepes"
+sv = "Medium"
 [modrinth.category.high]
 en = "High"
 de = "Hoch"
 hu = "Magas"
+sv = "Högt"
 [modrinth.category.screenshot]
 en = "Screenshot"
 de = "Screenshot"
 hu = "Képernyőkép"
+sv = "Skärmklipp"
 [modrinth.category.8x-]
 en = "8x or lower"
 de = "8x oder weniger"
 hu = "8x vagy kisebb"
+sv = "8x eller lägre"
 [modrinth.category.16x]
 en = "16x"
 de = "16x"
 hu = "16x"
+sv = "16x"
 [modrinth.category.32x]
 en = "32x"
 de = "32x"
 hu = "32x"
+sv = "32x"
 [modrinth.category.48x]
 en = "48x"
 de = "48x"
 hu = "48x"
+sv = "48x"
 [modrinth.category.64x]
 en = "64x"
 de = "64x"
 hu = "64x"
+sv = "64x"
 [modrinth.category.128x]
 en = "128x"
 de = "128x"
 hu = "128x"
+sv = "128x"
 [modrinth.category.256x]
 en = "256x"
 de = "256x"
 hu = "256x"
+sv = "256x"
 [modrinth.category."512x+"]
 en = "512x or higher"
 de = "512x oder höher"
 hu = "512x vagy nagyobb"
+sv = "512x eller högre"
 
 [modrinth.sort.relevance]
 en = "Relevance"
 de = "Relevanz"
 hu = "Relevancia"
+sv = 'Relevans'
 [modrinth.sort.downloads]
 en = "Downloads"
 de = "Downloads"
 hu = "Letöltések"
+sv = "Nedladdningar"
 [modrinth.sort.follows]
 en = "Follows"
 de = "Follower"
 hu = "Követők"
+sv = "Följare"
 [modrinth.sort.newest]
 en = "Newest"
 de = "Neuste"
 hu = "Legújabb"
+sv = "Nyast"
 [modrinth.sort.updated]
 en = "Updated"
 de = "Aktualisiert"
 hu = "Frissítve"
+sv = "Uppdaterat"
 
 [modrinth.environment.client_and_server]
-en = "Client and server"
+en = "Client and Server"
 de = "Client und Server"
-hu = "Kliens és szerver"
+hu = "Kliens és Szerver"
+sv = "Klient och Server"
 [modrinth.environment.client_only]
 en = "Client only"
 de = "Nur Client"
 hu = "Csak kliens"
+sv = "Endast Klient"
 [modrinth.environment.client_only_server_optional]
 en = "Client (server optional)"
 de = "Client (Server Optional)"
 hu = "Kliens (Szerver opcionális)"
+sv = "Klient (falfri Server)"
 [modrinth.environment.server_only]
 en = "Server only"
 de = "Nur Server"
 hu = "Csak szerver"
+sv = "Endast Server"
 [modrinth.environment.server_only_client_optional]
 en = "Server (client optional)"
 de = "Server (Client Optional)"
 hu = "Szerver (kliens opcionális)"
+sv = "Server (falfri Klient)"
 [modrinth.environment.client_or_server]
 en = "Client or server"
 de = "Client oder Server"
 hu = "Kliens vagy szerver"
+sv = "Klient och Server"
 [modrinth.environment.unknown_environment]
 en = "Unknown environment"
 de = "Unbekannte Umgebung"
 hu = "Ismeretlen környezet"
+sv = "Okänd miljö"
 
 [modrinth.versions.alpha]
 en = "${name: &str} (Alpha)"
 de = "${name: &str} (Alpha)"
 hu = "${name: &str} (Alpha)"
+sv = "${name: &str} (Alpha)"
 [modrinth.versions.beta]
 en = "${name: &str} (Beta)"
 de = "${name: &str} (Beta)"
 hu = "${name: &str} (Beta)"
+sv = "${name: &str} (Beta)"
 
 [curseforge.name]
 en = "Curseforge"
 de = "Curseforge"
 hu = "Curseforge"
+sv = "Curseforge"
 
 [curseforge.sort.popularity]
 en = "Popularity"
 de = "Popularität"
 hu = "Népszerűség"
+sv = "Populäritet"
 [curseforge.sort.downloads]
 en = "Downloads"
 de = "Downloads"
 hu = "Letöltések"
+sv = "Nedladdningar"
 [curseforge.sort.updated]
 en = "Updated"
 de = "Aktualisiert"
 hu = "Frissítve"
+sv = "Uppdaterat"
 [curseforge.sort.name]
 en = "Name"
 de = "Name"
 hu = "Név"
+sv = "Namn"
 [curseforge.sort.author]
 en = "Author"
 de = "Autor"
 hu = "Készítő"
+sv = "Skapare"
 
 [common.app_name]
 en = "Pandora"
 de = "Pandora"
 hu = "Pandora"
+sv = "Pandora"
 [common.unknown]
 en = "Unknown"
 de = "Unbekannt"
 hu = "Ismeretlen"
+sv = "Okänd"
 [common.search]
 en = "Search"
 de = "Suche"
 hu = "Keresés"
+sv = "Sök"
 [common.error]
 en = "Error"
 de = "Fehler"
 hu = "Hiba"
+sv = "Error"
 [common.latest]
 en = "Latest"
 de = "Neuste"
 hu = "Legújabb"
+sv = "Nyast"
 [common.update]
 en = "Update"
 de = "Aktualisiert"
 hu = "Frissítés"
+sv = "Uppdatera"
 [common.min]
 en = "Min"
 de = "Minimum"
 hu = "Minimum"
+sv = "Minst"
 [common.max]
 en = "Max"
 de = "Maximum"
 hu = "Maximum"
+sv = "Max"
 [common.or_upper]
 en = "OR"
 de = "ODER"
 hu = "VAGY"
+sv = "ELLER"
 [common.unset]
 en = "<unset>"
 de = "<ungesetzt>"
 hu = "<nincs megadva>"
+sv = "<avaktivera>"
 [common.custom]
 en = "Custom"
 de = "Benutzerdefiniert"
 hu = "Egyedi"
+sv = "Specialgjord"
 [common.cancel]
 en = "Cancel"
 de = "Abbrechen"
 hu = "Mégsem"
+sv = "Ångra"
 [common.reset]
 en = "Reset"
 de = "Zurücksetzen"
 hu = "Visszaállít"
+sv = "Återställ"
 [common.icon]
 en = "Icon"
 de = "Bild"
 hu = "Ikon"
+sv = "Ikon"
 [common.apply_changes]
 en = "Apply Changes"
 de = "Veränderungen anwenden"
 hu = "Változtatások alkalmazása"
+sv = "Applicera förändringarna"
 [common.ok]
 en = "OK"
 de = "OK"
 hu = "OK"
+sv = "OK"
 [common.nav.top]
 en = "Go to Top"
 de = "Nach Oben"
 hu = "Ugrás felülre"
+sv = "Gå till Toppen"
 [common.nav.bottom]
 en = "Go to Bottom"
 de = "Nach Unten"
 hu = "Ugrás allulra"
+sv = "Gå till Botten"
 [common.layout.cards]
 en = "Cards"
 de = "Karten"
 hu = "Kártyák"
+sv = "Kort"
 [common.layout.list]
 en = "List"
 de = "Liste"
 hu = "Lista"
+sv = "Lista"
 
 [file_system.open_folder.error]
 en = "Unable to open folder: ${err: std::io::Error}"
 de = "Konnte Ordner nicht öffnen: ${err: std::io::Error}"
 hu = "Nem sikerült megnyitni a mappát: ${err: std::io::Error}"
+sv = "Kunde ej öppan folderna: ${err: std::io::Error}"
 [file_system.open_folder.not_a_directory]
 en = "Unable to open folder: not a directory"
 de = "Konnte Ordner nicht öffnen: ist kein Ordner"
 hu = "Nem sikerült megnyitni a mappát: nem egy mappa"
+sv = "Kunde ej öppna foldern: inte en katalog"
 
 [system.backend_shutdown]
 en = "Backend has abruptly shutdown"
 de = "Das Backend ist unerwartet abgestürzt"
 hu = "A háttérfolyamat váratlanul leállt"
+sv = "Backgrundsprocessen stoppades oväntat"
 [system.metadata_error]
 en = "Wrong metadata type! Pandora bug!"
 de = "Falscher Metadaten Type! Pandora Fehler!"
 hu = "Hibás metaadat típus! Pandora hiba!"
+sv = "Fel medatata typ! En bug hos oss (Pandora)"
 [system.game_output]
 en = "Minecraft Game Output"
 de = "Minecraft Log Ausgabe"
 hu = "Minecraft játéknapló"
+sv = "Minecraft Log utmatning"
 
 [system.update.title]
 en = "Update Pandora?"
 de = "Pandora aktualisieren?"
 hu = "Frissíted a Pandorát?"
+sv = "Uppdatera Pandora?"
 [system.update.current]
 en = "Current version: ${ver: &str}"
 de = "Aktuelle Version: ${ver: &str}"
 hu = "Jelenlegi verzió: ${ver: &str}"
+sv = "Nuvarande version: ${ver: &str}"
 [system.update.new]
 en = "New version: ${ver: &str}"
 de = "Neue Version: ${ver: &str}"
 hu = "Új verzió: ${ver: &str}"
+sv = "Ny version: ${ver: &str}"
 [system.update.size.bytes]
 en = "Update size: ${num: usize} bytes"
 de = "Größe der Aktualisierung: ${num: usize} bytes"
 hu = "Frissítés mérete: ${num: usize} byte"
+sv = "Updateringsstorlek: ${num: usize} byte"
 [system.update.size.kb]
 en = "Update size: ${num: usize}kB"
 de = "Größe der Aktualisierung: ${num: usize}kB"
 hu = "Frissítés mérete: ${num: usize}kB"
+sv = "Updateringsstorlek: ${num: usize}kB"
 [system.update.size.mb]
 en = "Update size: ${num: usize}MB"
 de = "Größe der Aktualisierung: ${num: usize}MB"
 hu = "Frissítés mérete: ${num: usize}MB"
+sv = "Updateringsstorlek: ${num: usize}MB"
 [system.update.size.gb]
 en = "Update size: ${num: usize}GB"
 de = "Größe der Aktualisierung: ${num: usize}GB"
 hu = "Frissítés mérete: ${num: usize}GB"
+sv = "Updateringsstorlek: ${num: usize}GB"
 [system.update.later]
 en = "Later"
 de = "Später"
 hu = "Később"
+sv = "Senare"
 [system.update.install_error]
 en = "Unable to install update"
 de = "Aktualisierung konnte nicht installiert werden"
 hu = "Nem sikerült a frissítés telepítése"
+sv = "Kunde ej installera uppdateringen"
 
 [account.title]
 en = "Accounts"
 de = "Konten"
 hu = "Fiókok"
+sv = "Konton"
 [account.override_account]
 en = "Override Account"
 de = "Konto Überschreiben"
 hu = "Fiók felülírása"
+sv = "Åsidosätt Konto"
 [account.none]
 en = "No Account"
 de = "Kein Konto"
 hu = "Nincs fiók"
+sv = "Inget Konto"
 [account.name]
 en = "Name"
 de = "Name"
 hu = "Név"
+sv = "Namn"
 [account.uuid]
 en = "UUID"
 de = "UUID"
 hu = "UUID"
+# do people know this?
+sv = "UUID"
 [account.uuid_random]
 en = "Random"
 de = "Zufällig"
 hu = "Random"
+sv = "Random"
 [account.add.title]
 en = "Adding new account"
 de = "Füge neues Konto hinzu"
 hu = "Másik fiók hozzáadása"
+sv = "Lägger till nytt konto"
 [account.add.label]
 en = "Add account"
 de = "Konto hinzufügen"
 hu = "Fiók hozzáadása"
+sv = "Lägg till konto"
 [account.add.submit]
 en = "Add"
 de = "Hinzufügen"
 hu = "Hozzáadás"
+sv = "Lägg till"
 [account.add.offline]
 en = "Add Offline Account"
 de = "Offline Konto hinzufügen"
 hu = "Offline fiók hozzáadása"
+sv = "Lägg till offline-konto"
 [account.add.error]
 en = "Error adding account"
 de = "Fehler beim Konto hinzufügen"
 hu = "Hiba történt a fiók hozzáadásakor"
+sv = "Kunde ej lägga till konto"
 
 [instance.title]
 en = "Instances"
 de = "Instanzen"
 hu = "Példányok"
+sv = "Instanser"
 [instance.label]
 en = "Instance"
 de = "Instanz"
 hu = "Példány"
+sv = "Instans"
 [instance.recent]
 en = "Recent Instances"
 de = "Letze Instanzen"
 hu = "Legutóbbi példányok"
+sv = "Senaste instanserna"
 [instance.none_selected]
 en = "Select an instance"
 de = "Wähle eine Instanz aus"
 hu = "Válassz egy példányt"
+sv = "Välj en instans"
 [instance.unnamed]
 en = "Unnamed Instance"
 de = "Unbekannte Instanz"
 hu = "Névtelen példány"
+sv = "namlös instans"
 [instance.incompatible]
 en = "(${num: usize} instances were incompatible)"
 de = "(${num: usize} instanzen waren inkompatiebel)"
 hu = "(${num: usize} példány nem kompatibilis"
+sv = "(${num: usize} instanserna var okompatibla"
 [instance.new]
 en = "New Instance"
 de = "Neue Instanz"
 hu = "Új példány"
+sv = "Ny instans"
 [instance.quickplay]
 en = "Quickplay"
 de = "Schnellspiel"
 hu = "Gyorsjáték"
+sv = "snabbspel"
 [instance.worlds]
 en = "Worlds"
 de = "Welten"
 hu = "Világok"
+sv = "Världar"
 [instance.servers]
 en = "Servers"
 de = "Server"
 hu = "Szerverek"
+sv = "Servrar"
 [instance.total_playtime]
 en = "Total Playtime"
 de = "Insgesammte Spielzeit"
 hu = "Össz játékidő"
+sv = "Total speltid"
 [instance.current_session]
 en = "Current Session"
 de = "Aktuelle Sitzung"
 hu = "Jelenlegi játékmenet"
+sv = "Nuvarande Session"
 [instance.vanilla]
 en = "Vanilla"
 de = "Vanilla"
 hu = "Vanilla"
+sv = "Vanilla"
 [instance.unable_to_find]
 en = "Unable to find instance"
 de = "Instanz konnte nicht gefunden werden"
 hu = "Példány nem található"
+sv = "Kunde ej hitta instans"
 [instance.start.title]
 en = "Launching ${name: &str}"
 de = "Starte ${name: &str}"
 hu = "${name: &str} indítása"
+sv = "Startar ${name: &str}"
 [instance.start.label]
 en = "Start"
 de = "Start"
 hu = "Játék"
+sv = "Starta"
 [instance.start.starting]
 en = "Launching..."
 de = "Startet..."
 hu = "Indítás..."
+sv = "Startar..."
 [instance.start.stopping]
 en = "Stopping..."
 de = "Stoppen..."
 hu = "Leállítás..."
+sv = "Stoppar..."
 [instance.start.error]
 en = "Error starting instance"
 de = "Fehler beim Starten der Instanz"
 hu = "Hiba a példány indításakor"
+sv = "Ett fel uppstod då instansen startade"
 [instance.play]
 en = "Play"
 de = "Spiel"
 hu = "Játék"
+sv = "Spela"
 [instance.view]
 en = "View"
 de = "Ansehen"
 hu = "Nézet"
+sv = "Visa"
 [instance.kill]
 en = "Kill"
 de = "Stoppen"
 hu = "Leállítás"
+sv = "Stoppa"
 [instance.kill_instance]
 en = "Kill Instance"
 de = "Stope Instanz"
 hu = "Példány leállítása"
+sv = "Stoppa instansen"
 [instance.delete]
 en = "Delete this instance"
 de = "Lösche diese Instanz"
 hu = "Ez a példány törlése"
+sv = "Radera den här instansen"
 [instance.create_shortcut]
 en = "Create shortcut"
 de = "Verknüpfung erstellen"
 hu = "Gyorsgomb létrehozása"
+sv = "Skapa en genväg"
 [instance.open_folder]
 en = "Open .minecraft folder"
 de = "Öffne .minecraft Ordner"
 hu = ".minecraft mappa megnyitása"
+sv = "Öppna .minecraft mappen"
 [instance.create]
 en = "Create Instance"
 de = "Erstelle Instanz"
 hu = "Példány létrehozása"
+sv = "Skapa Instans"
 [instance.name]
 en = "Name"
 de = "Name"
 hu = "Név"
+sv = "Namn"
 [instance.name_placeholder]
 en = "<instance name>"
 de = "<Instanz Name>"
 hu = "<példány neve"
+sv = "<instansens namn>"
 [instance.version]
 en = "Version"
 de = "Version"
 hu = "Verzió"
+sv = "Version"
 [instance.loader]
 en = "Loader"
 de = "Loader"
 hu = "Betöltő"
+sv = "Loader"
 [instance.loader_version]
 en = "${loader: &str} Version"
 de = "${loader: &str} Version"
 hu = "${loader: &str} Verzió"
+sv = "${loader: &str} Version"
 [instance.game_version]
 en = "Game Version"
 de = "Spielversion"
 hu = "Játék verzió"
+sv = "Spelversion"
 [instance.mc_version]
 en = "Minecraft Version"
 de = "Minecraft Version"
 hu = "Minecraft verzió"
+sv = "Minecraft Version"
 [instance.show_snapshots]
 en = "Show Snapshots"
 de = "Vorabversionen anzeigen"
 hu = "Snapshot-ok mutatása"
+sv = "Visa Snapshots"
 [instance.modloader]
 en = "Modloader"
 de = "Modloader"
 hu = "Modloader"
+sv = "Modloader"
 [instance.select_icon]
 en = "Select Icon"
 de = "Bild auswählen"
 hu = "Válassz ikont"
+sv = "Välj Ikon"
 [instance.select_png_icon]
 en = "Select PNG Icon"
 de = "PNG Bild auswählen"
 hu = "Válassz egy PNG ikont"
+sv = "Välj PNG ikon"
 [instance.instance_name]
 en = "Instance name"
 de = "Instanzname"
 hu = "Példány neve"
+sv = "Instans namn"
 [instance.invalid_name]
 en = "Invalid name"
 de = "Invalieder Name"
 hu = "Érvénytelen név"
+sv = "Ogiltigt namn"
 [instance.export.action]
 en = "Export"
 hu = "Export"
+sv = "Exportera"
 [instance.export.title]
 en = "Export Instance"
 hu = "Példány exportálása"
+sv = "Exportera instansen"
 [instance.export.progress]
 en = "Exporting instance"
 hu = "Példány exportálása"
+sv = "Exporterar instansen"
 [instance.export.error]
 en = "Error exporting instance"
 hu = "Hiba a példány exportálása közben"
+sv = "Fel vid export av instans"
 [instance.export.format.label]
 en = "Format"
 hu = "Formátum"
+sv = "Format"
 [instance.export.format.zip]
 en = "Instance Zip"
 hu = "Példány Zip"
+sv = "Instans Zip-fil"
 [instance.export.format.modrinth]
 en = "Modrinth Pack (.mrpack)"
 hu = "Modrinth Pack (.mrpack)"
+sv = "Modrinth Pack (.mrpack)"
 [instance.export.format.curseforge]
 en = "CurseForge Pack (.zip)"
 hu = "CurseForge Pack (.zip)"
+sv = "CurseForge Pack (.zip)"
 [instance.export.options]
 en = "Export Options"
 hu = "Export beállítások"
+sv = "Exportera alternativ"
 [instance.export.modrinth_options]
 en = "Modrinth Options"
 hu = "Modrinth beállítások"
+sv = "Modrinth inställningar"
 [instance.export.curseforge_options]
 en = "CurseForge Options"
 hu = "CurseForge beállítások"
+sv = "CurseForge inställningar"
 [instance.export.include_saves]
 en = "Include saves"
 hu = "Mentések belefoglalása"
+sv = "Inkludera världar"
 [instance.export.include_mods]
 en = "Include mods"
 hu = "Modok belefoglalása"
+sv = "Inkludera mods"
 [instance.export.include_resourcepacks]
 en = "Include resourcepacks"
 hu = "forráscsomagok belefoglalása"
+sv = "Inkludera resurspacket"
 [instance.export.include_configs]
 en = "Include configs"
 hu = "Konfigurációk belefoglalása"
+sv = "Inkludera konfigurationsfiler"
 [instance.export.include_logs]
 en = "Include logs/crash reports"
 hu = "Naplófájlok/összeomlási jelentések belefoglalása"
+sv = "Inkludera loggar/krashrapporteringar"
 [instance.export.include_cache]
 en = "Include cache files"
 hu = "Gyorsítótár fájlok belefoglalása"
+sv = "Inkludera Cache filer"
 [instance.export.include_synced]
 en = "Include synced folders"
 hu = "Szinkronizált mappák belefoglalása"
+sv = "Inkludera synkade foldrar"
 [instance.export.name]
 en = "Name"
 hu = "Név"
+sv = "Namn"
 [instance.export.version]
 en = "Version"
 hu = "Verzió"
+sv = "version"
 [instance.export.summary]
 en = "Summary"
 hu = "Összegzés"
+sv = "Sammanfattning"
 [instance.export.author]
 en = "Author"
 hu = "Szerző"
+sv = "Författare"
 [instance.export.recommended_ram]
 en = "Recommended RAM"
 hu = "Ajánlott RAM"
+sv = "Rekommenderat RAM-minne"
 [instance.versions_loading.game_versions]
 en = "Loading Minecraft Versions..."
 de = "Lade Minecraft Versionen..."
 hu = "Minecraft verziók betöltése..."
+sv = "Laddar Minecraft Versioner..."
 [instance.versions_loading.reload]
 en = "Reload Versions"
 de = "Versionen neuladen"
 hu = "Verziók újratöltése"
+sv = "Ladda om Versioner"
 [instance.versions_loading.possible_loader_error]
 en = "Error loading possible loader versions"
 de = "Fehler beim Laden möglicher Modloader-Versionen"
 hu = "Hiba történt a lehetséges verziók betöltésekor"
+sv = "Ett fel uppstod då möjliga versioner skulle laddas in"
 [instance.versions_loading.error]
 en = "Error loading Minecraft versions"
 de = "Fehler beim laden von Minecraft Versionen"
 hu = "Hiba a Minecraft verziók betöltésekor"
+sv = "Ett vid laddning av Minecraft versioner"
 [instance.memory]
 en = "Set Memory"
 de = "Arbeitsspeicher"
 hu = "Memória beállítása"
+sv = "RAM-minne"
 [instance.wrapper_command]
 en = "Add Wrapper Command"
 de = "Füge Wrapper Befehl hinzu"
 hu = "Wrapper parancs hozzáadása"
+sv = "Lägg till ett wrapper-kommand"
 [instance.jvm_flags]
 en = "Add JVM Flags"
 de = "Fügen JVM Argumente hinzu"
 hu = "JVM argumentumok hozzáadása"
+sv = "Lägg till JVM-argument"
 [instance.jvm_binary]
 en = "Override JVM Binary"
 de = "Überschreibe JVM Binary"
 hu = "JVM Binary felülírása"
+sv =  "Överskrid JVM programfil"
 [instance.select_jvm_binary]
 en = "Select JVM Binary"
 de = "Wähle JVM Binary aus"
 hu = "JVM Binary választása"
+sv = "Välj JVM programfil"
 [instance.glfw_lib]
 en = "Use System GLFW"
 de = "Verwende System GLFW"
 hu = "Rendszer GLFW használata"
+sv = "Välj systemets GLFW"
 [instance.select_glfw_lib]
 en = "Select GLFW Library"
 de = "Wähle GLFW Bibiliothek aus"
 hu = "GLFW könyvtár kiválasztása"
+sv = "Välj GLFW bibliotek"
 [instance.openal_lib]
 en = "Use System OpenAL"
 de = "Verwende System OpenAL"
 hu = "Rendszer OpenAL használata"
+sv = "Använd Systemets OpenAL (Ljud programvaru-bibliotek)"
 [instance.select_openal_lib]
 en = "Select OpenAL Library"
 de = "Wähle OpenAL Bibiliothek aus"
 hu = "OpenAL könyvtár választása"
+sv = "Välj OpenAL Bibliotek"
 
 [instance.security.label]
 en = "Security"
 de = "Sicherheit"
 hu = "Biztonság"
+sv = "Säkerhet"
 [instance.security.sandbox]
 en = "Sandbox"
 de = "Isolierung"
 hu = "Izolálás"
+sv = "Sandlådeisolering"
 
 [instance.linux.label]
 en = "Linux Performance"
 de = "Linux Performance"
 hu = "Linux teljesítmény"
+sv = "Linux Prestanda"
 [instance.linux.use_mangohud]
 en = "Use MangoHud"
 de = "Nutze MangoHud"
 hu = "MangoHud használata"
+sv = "Använd MangoHud"
 [instance.linux.use_gamemode]
 en = "Use GameMode"
 de = "Nutze GameMode"
 hu = "GameMode használata"
+sv = "Använd GameMode"
 [instance.linux.use_discrete_gpu]
 en = "Use Discrete GPU"
 de = "Diskrete GPU verwenden"
 hu = "Diszkrét GPU használata"
+sv = "Använd diskret grafikkort"
 [instance.linux.disable_gl_threaded_optimizations]
 en = "Disable GL Threaded Optimizations"
 de = "GL-Thread-Optimierungen deaktivieren"
 hu = "GL-Thread-Optimizációk kikapcsolása"
+sv = "Inaktivera GL-trådade optimeringar"
 
 [instance.delete_dialog.title]
 en = "Delete Instance: ${name: &str}"
 de = "Lösche Instanz: ${name: &str}"
 hu = "Példány törlése: ${name: &str}"
+sv = "Radera Instansen: ${name: &str}"
 [instance.delete_dialog.label]
 en = "I want to delete this instance"
 de = "Ich möchte diese Instanz löschen"
 hu = "Törölni akarom ezt a példányt"
+sv = "Jag vill ta bort instansen"
 [instance.delete_dialog.check]
 en = "I have read and understand these effects"
 de = "Ich habe die Konsequenzen gelesen und verstanden"
 hu = "Elolvastam és megértettem a következményeket"
+sv = "Jag har läst och förstått dessa effekter"
 [instance.delete_dialog.confirm_text]
 en = "To confirm, type '${name: &str}' in the box below"
 de = "Um zu bestätigen gebe „${name: &str}“ ein"
 hu = "A megerősítéshez írd be, hogy '${name: &str}' az alábbi mezőbe"
+sv = "Föra att konfirmera, skriv '${name: &str}' i lådan under"
 [instance.delete_dialog.warning]
 en = "This will permanently delete the '${name: &str}' instance and associated saves, resourcepacks, mods, configuration files, and more. These files will not be recoverable"
 de = "Dadurch will die Instanz „${name: &str}“ sowie die zugehörigen Spielstände, Ressourcenpakete, Mods, Konfigurationsdateien und weitere Elemente endgültig gelöscht. Diese Dateien können nicht wiederhergestellt werden."
 hu = "Ez örökre törölni fogja a(z) '${name: &str}' példányt és a hozzá tartozó mentéseket, forráscsomagokat, konfigurációs fájlokat és másokat. Ezek a fájlok nem lesznek visszaszerezhetőek"
+sv = "Detta kommer att permanent radera instansen med namn: '${name: &str}' och tillhörande sparade världar, resurspaket, mods, konfigurationsfiler och mer. Dessa filer kommer inte att kunna återställas"
 
 [instance.logs.title]
 en = "Logs"
 de = "Protokolle"
 hu = "Naplók"
+sv = "Loggar"
 [instance.logs.none]
 en = "No available logs"
 de = "Keine verfügbare Protokolle"
 hu = "Nincs elérhető naplófájl"
+sv = "Inga tillgängliga loggar"
 [instance.logs.loading]
 en = "Loading available logs..."
 de = "Lade verfügbare Protokolle..."
 hu = "Elérhető naplófájlok betöltése..."
+sv = "Laddar tillgängliga loggar..."
 [instance.logs.cleanup.bytes]
 en = "Cleanup old log files (${num: usize} bytes)"
 de = "Räume alte Protokolle auf (${num: usize} bytes)"
 hu = "Régi naplófájlok tisztítása (${num: usize} byte)"
+sv = "Städa upp gamla logg-filer (${num: usize} bytes)"
 [instance.logs.cleanup.kb]
 en = "Cleanup old log files (${num: usize}kB)"
 de = "Räume alte Protokolle auf (${num: usize}kB)"
 hu = "Régi naplófájlok tisztítása (${num: usize}kB)"
+sv = "Städa upp gamla logg-filer (${num: usize}kB)"
 [instance.logs.cleanup.mb]
 en = "Cleanup old log files (${num: usize}MB)"
 de = "Räume alte Protokolle auf (${num: usize}MB)"
 hu = "Régi naplófájlok tisztítása (${num: usize}MB)"
+sv = "Städa upp gamla logg-filer (${num: usize}MB)"
 [instance.logs.cleanup.gb]
 en = "Cleanup old log files (${num: usize}GB)"
 de = "Räume alte Protokolle auf (${num: usize}GB)"
 hu = "Régi naplófájlok tisztítása (${num: usize}GB)"
+sv = "Städa upp gamla logg-filer (${num: usize}GB)"
 [instance.logs.select_file]
 en = "Select log file"
 de = "Wähle Protokolle aus"
 hu = "Válassz naplófájlt"
+sv = "Välj log-fil"
 [instance.logs.upload.label]
 en = "Upload"
 de = "Hochladen"
 hu = "Feltöltés"
+sv = "Ladda upp"
 [instance.logs.upload.title]
 en = "Uploading log file"
 de = "Lade Protokolle"
 hu = "Naplófájl feltöltése"
+sv = "Ladda upp log-fil"
 [instance.logs.upload.error]
 en = "Error uploading log file"
 de = "Fehler beim Hochladen von Protokollen"
 hu = "Hiba a naplófájl feltöltésekor"
+sv = "Fel vid uppladdninga var loggar"
 
 [instance.content.title]
 en = "Content"
 de = "Inhalt"
 hu = "Tartalom"
+sv = "Innehåll"
 [instance.content.mods]
 en = "Mods"
 de = "Mods"
 hu = "Modok"
+sv = "Mods"
 [instance.content.modpacks]
 en = "Modpacks"
 de = "Modpakete"
 hu = "Modcsomagok"
+sv = "Modpack"
 [instance.content.resourcepacks]
 en = "Resourcepacks"
 de = "Ressourcenpakete"
 hu = "Forráscsomagok"
+sv = "Resurspacket"
 [instance.content.shaders]
 en = "Shaders"
 de = "Shaders"
 hu = "Shaderek"
+sv = "Shaders"
 [instance.content.filename_prefix]
 en = "Filename: "
 de = "Dateiname: "
 hu = "Fájlnév: "
+sv = "Filnamn: "
 [instance.content.version.mod]
 en = "Mod Version"
 de = "Mod Version"
 hu = "Mod verzió"
+sv = "Mod-version"
 [instance.content.version.modpack]
 en = "Modpack Version"
 de = "Modpaket Version"
 hu = "Modcsomag verzió"
+sv = "Modpacks-Version"
 [instance.content.version.resourcepack]
 en = "Pack Version"
 de = "Paket Version"
 hu = "Csomag verzió"
+sv = "Paket-version"
 [instance.content.version.shader]
 en = "Shader Version"
 de = "Shader Version"
 hu = "Shader verzió"
+sv = "Shader-Version"
 [instance.content.version.file]
 en = "File Version"
 de = "Dateiversion"
 hu = "File verzió"
+sv = "Fil-Version"
 [instance.content.search.mod]
 en = "Search mods..."
 de = "Suche Mods..."
 hu = "Modok keresése..."
+sv = "Sök Mods..."
 [instance.content.search.modpack]
 en = "Search modpacks..."
 de = "Suche Modpakete..."
 hu = "Modcsomagok keresése..."
+sv = "Sök modpacks..."
 [instance.content.search.resourcepack]
 en = "Search resourcepacks..."
 de = "Suche Ressourcenpakete..."
 hu = "Forráscsomagok keresése..."
+sv = "Sök resurspaket..."
 [instance.content.search.shader]
 en = "Search shaders..."
 de = "Suche Shader..."
 hu = "Shaderek keresése..."
+sv = "Sök shaders..."
 [instance.content.search.file]
 en = "Search..."
 de = "Suche..."
 hu = "Keresés..."
+sv = "Sök..."
 [instance.content.requesting_from_modrinth_error]
 en = "Error requesting from Modrinth"
 de = "Fehler beim Abrufen von Modrinth"
 hu = "Hiba a Modrinth lekérése közben"
+sv = "Fel vid hämtning från Modrinth"
 [instance.content.unnamed]
 en = "Unnamed"
 de = "Unbenannt"
 hu = "Névtelen"
+sv = "Namnlös"
 [instance.content.open_page]
 en = "Open Page"
 de = "Öffne Seite"
 hu = "Oldal megnyitása"
+sv = "Öppna sida"
 [instance.content.by]
 en = "by ${name: &str}"
 de = "von ${name: &str}"
 hu = "tőle: ${name: &str}"
+sv = "av ${name: &str}"
 [instance.content.no_description]
 en = "No Description"
 de = "Keine Beschreibung"
 hu = "Nincs leírás"
+sv = "Igen beskrivning"
 [instance.content.error_loading]
 en = "Error loading project"
 de = "Fehler beim laden vom Projekt"
 hu = "Hiba a projekt betöltésekor"
+sv = "Fel vid laddning av projekt"
 [instance.content.no_gallery]
 en = "No gallery images"
 de = "Keine Bilder"
 hu = "Nincsnek galéria képek"
+sv = "Inget bildgalleri"
 [instance.content.tabs.description]
 en = "Description"
 de = "Beschreibung"
 hu = "Leírás"
+sv = "Beskrivning"
 [instance.content.tabs.gallery]
 en = "Gallery"
 de = "Gallerie"
 hu = "Galéria"
+sv = "Galleri"
 [instance.content.links.source]
 en = "Source"
 de = "Quellcode"
 hu = "Forrás"
+sv = "Källa"
 [instance.content.links.issues]
 en = "Issues"
 de = "Fehler melden"
 hu = "Hiba jelentések"
+sv = "Problem"
 [instance.content.links.wiki]
 en = "Wiki"
 de = "Wiki"
 hu = "Wiki"
+sv = "Wiki"
 [instance.content.links.discord]
 en = "Discord"
 de = "Discord"
 hu = "Discord"
+sv = "Discord"
 [instance.content.categories]
 en = "Categories"
 de = "Kategorien"
 hu = "Kategóriák"
+sv = "Kategorier"
 [instance.content.sort]
 en = "Sort by"
 de = "Sortieren nach"
 hu = "Rendszerezés"
+sv = "Sortera efter"
 [instance.content.downloads.b]
+# Billion
 en = "${num: f64}B Downloads"
 de = "${num: f64}Mrd. Downloads"
 hu = "${num: f64}Mrd letöltés"
+sv = "${num: f64}md Nedladdningar"
 [instance.content.downloads.m]
 en = "${num: f64}M Downloads"
 de = "${num: f64}Mil. Downloads"
 hu = "${num: f64}M letöltés"
+sv = "${num: f64}mn Nedladdningar"
 [instance.content.downloads.k]
 en = "${num: f64}K Downloads"
 de = "${num: f64}Tsd. Downloads"
 hu = "${num: f64}E letöltés"
+sv = "${num: f64}k Nedladdningar"
 [instance.content.downloads.n]
 en = "${num: u64} Downloads"
 de = "${num: u64} Downloads"
 hu = "${num: u64} letöltés"
+sv = "${num: u64} Nedladdningar"
 [instance.content.load.versions.title]
 en = "Loading mod versions..."
 de = "Lade Mod Versionen..."
 hu = "Mod verziók betöltése"
+sv = "Laddar mod versioner..."
 [instance.content.load.versions.not_found]
 en = "No mod versions found"
 de = "Keine Mod Versionen gefunden"
 hu = "Nem találhatók mod verziók"
+sv = "Inga mod versioner hittade"
 [instance.content.load.versions.not_found_for]
 en = "No mod versions found for ${ver: &str}"
 de = "Keine Mod Version für ${ver: &str} gefunden"
 hu = "Nem található mod verzió a(z) ${ver: &str} verzióhoz"
+sv = "Inga mod versioner hittade för ${ver: &str}"
 [instance.content.load.versions.not_found_for_loader]
 en = "No mod versions found for ${loader: &str} ${ver: &str}"
 de = "Keine Mod Version für ${loader: &str} ${ver: &str} gefunden"
 hu = "Nem található verzió a(z) ${loader: &str} ${ver: &str} loaderhez"
+sv = "Inga mod versioner hittade för ${loader: &str} ${ver: &str}"
 [instance.content.load.versions_from_modrinth.title]
 en = "Loading project versions from Modrinth..."
 de = "Lade Projektversionen von Modrinth..."
 hu = "Projekt verziók betöltése a Modrinthről..."
+sv = "Laddar projektets versioner från Modrinth"
 [instance.content.load.versions_from_modrinth.error]
 en = "Error loading project versions from Modrinth: ${err: &str}"
 de = "Fehler beim laden von Projektversionen von Modrinth: ${err: &str}"
 hu = "Hiba a projekt verziók betöltésekor a Modrinthről: ${err: &str}"
+sv = "Fel vid laddning av projektversioner från Modrinth: ${err: &str}"
 [instance.content.install.label]
 en = "Install"
 de = "Installieren"
 hu = "Telepítés"
+sv = "Installera"
 [instance.content.install.title]
 en = "Install ${name: &str}"
 de = "Installiere ${name: &str}"
 hu = "${name: &str} telepítése"
+sv = "Installera ${name: &str}"
 [instance.content.install.reinstall]
 en = "Reinstall"
 de = "Neuinstallieren"
 hu = "Újratelepítés"
+sv = "Ominstallera"
 [instance.content.install.latest]
 en = "Install Latest"
 de = "Installiere neuste Version"
 hu = "Legújabb telepítése"
+sv = "Installerar nyaste"
 [instance.content.install.error]
 en = "Error installing content"
 de = "Fehler beim installieren von Inhalt"
 hu = "Hiba a tartalom telepítésekor"
+sv = "Fel vid installation av innehåll"
 [instance.content.install.always_latest]
 en = "Always install the latest version. Untick to be able to choose older versions of content to install"
 de = "Installiert immer die neuste Version. Deaktivieren um ältere Versionen installieren zu können"
 hu = "Mindíg a legújabb telepítése. Szedd ki a pipát, hogy régebbi verziót tudj telepíteni"
+sv = "Installera alltid den senaste versionen. Avmarkera om du vill kunna välja äldre versioner av innehåll att installera."
 [instance.content.install.from_modrinth]
 en = "Add from Modrinth"
 de = "Von Modrinth hinzufügen"
 hu = "Hozzáadás Modrinthről"
+sv = "Lägg till från Modrinth"
 [instance.content.install.from_curseforge]
 en = "Add from Curseforge"
 de = "Von Curseforge hinzufügen"
 hu = "Hozzáadás Curseforgeról"
+sv = "Lägg till från Curseforge"
 [instance.content.install.from_file]
 en = "Add from file"
 de = "Von Datei hinzufügen"
 hu = "Hozzáadás fájlból"
+sv = "Lägg till från fil"
 [instance.content.install.unable_other_type]
 en = "Unable to install 'other' project type"
 de = "Konnte Projektart „anderes“ nicht Installieren"
 hu = "Nem lehet telepíteni a 'más' projekt típust"
+sv = "Det gick inte att installera projekttypen 'annan'"
 [instance.content.install.invalid_filename]
 en = "Invalid/dangerous filename"
 de = "Invalieder/Gefährlicher Dateinname"
 hu = "Érvénytelen/veszélyes fájlnév"
+sv = "Ogilgit/farligt filnamn"
 [instance.content.install.missing_sha1_hash]
+#WARN: I do not think users know what sha1 is 
 en = "Missing sha1 hash"
 de = "Fehlender sha1 Hash"
 hu = "Hiányzik az sha1 hash"
+sv = "saknad sha1-hash"
 [instance.content.install.no_third_party_downloads]
 en = "The mod author has blocked downloads from third-party launchers"
 de = "Der Mod Autor hat das herunterladen von Drittanbietern blockiert"
 hu = "A mod készítője letiltotta a harmadik féltől származó indítókon keresztüli letöltéseket"
+sv = "Modförfattaren har blockerat nedladdningar från tredjeparts launchers"
 [instance.content.install.select_mods]
 en = "Select mods to install"
 de = "Wähle zu installierende Mods aus"
 hu = "Válaszd ki a telepíteni kívánt modokat"
+sv = "Välj mods att installera"
 [instance.content.install.new_instance_with.mod]
 en = "Create new instance with this mod"
 de = "Erstelle neue Instanz mit dieser Mod"
 hu = "Új példány létrehozása ezzel a moddal"
+sv = "Skapa en ny instans med detta mod"
 [instance.content.install.new_instance_with.modpack]
 en = "Create new instance with this modpack"
 de = "Erstelle eine neue Instanz mit diesem Modpaket"
 hu = "Új példány létrehozása ezzel a modcsomaggal"
+sv = "Skapa en ny instans med detta modpacket"
 [instance.content.install.new_instance_with.resourcepack]
 en = "Create new instance with this resourcepack"
 de = "Erstelle eine neue Instanz mit diesem Ressourcenpaket"
 hu = "Új példány létrehozása ezzel a forráscsomaggal"
+sv = "Skapa en ny instans med detta resurspacket"
 [instance.content.install.new_instance_with.shader]
 en = "Create new instance with this shader"
 de = "Erstelle eine neue Instanz mit diesem Shader"
 hu = "Új példány létrehozása ezzel a shaderrel"
+sv = "Skapa en ny instans med denna shader"
 [instance.content.install.new_instance_with.file]
 en = "Create new instance with this file"
 de = "Erstelle eine neue Instanz mit dieser Datei"
 hu = "Új példány létrehozása ezzel a fájllal"
+sv = "Skapa en ny instans med denna fil"
 [instance.content.install.add_to_instance]
 en = "Add to instance"
 de = "Zu Instanz hinzufügen"
 hu = "Hpzzáadás a példányhoz"
+sv = "Lägg till i instans"
 [instance.content.install.install_dependency]
 en = "Install 1 dependency"
 de = "Installiere 1 Abhängigkeit"
 hu = "1 függőség telepítése"
+sv = "Installera 1 beroende"
 [instance.content.install.install_dependencies]
 en = "Install ${num: usize} dependencies"
 de = "Installiere ${num: usize} Abhängigkeiten"
 hu = "${num: usize} függőség telepítés"
+sv = "Installera ${num: usize} beroenden"
 [instance.content.install.no_mod_version_selected]
 en = "No mod version selected"
 de = "Keine Modversion ausgewählt"
 hu = "Nincs kiválasztva mod verzió"
+sv = "Igen mod-version vald"
 [instance.content.install.unable_install_other]
 en = "Unable to install 'other' project type"
 de = "Konnte Projekttype „Anderes“ nicht installieren"
 hu = "Nem lehet telepíteni a 'más' projekt típust"
+sv = "Kunde ej installera 'andra' projekt-typ"
 [instance.content.install.no_matching_versions]
 en = "Unable to find matching version of project"
 de = "Es konnte keine passende Version des Projekts gefunden werden"
 hu = "Nem található egyező projekt verzió"
+sv = "Kunde ej hitta matchande version av projekt"
 [instance.content.install.unknown_type]
 en = "Don't know how to handle this type of content"
 de = "Keine Ahnung wie man diesem Typ von Inhalt installiert"
 hu = "Nem lehet kezelni ezt a típúsú tartalmat"
+sv = "Vet ej hur man hanterar denna typ av innehåll"
 [instance.content.install.select_resourcepacks]
 en = "Select resource packs to install"
 de = "Wähle Ressourcenpakete aus um sie zu installieren"
 hu = "Válaszd ki a telepíteni kívánt forráscsomagokat"
+sv = "Välj resurspaket att installera"
 [instance.content.install.select_shaders]
 en = "Select shaders to install"
+sv = "Välj shaders att installera"
 [instance.content.update.label]
 en = "Update"
 de = "Aktualisieren"
 hu = "Frissítés"
+sv = "Uppdatera"
 [instance.content.update.check.label]
 en = "Check for updates"
 en_short = "Update Check"
@@ -1312,327 +1643,411 @@ de = "Nach Aktualisieren suchen"
 de_short = "Aktualisierungs Prüfung"
 hu = "Frissítések keresése"
 hu_short = "Frissítés keresése"
+sv = "Kolla efter uppdateringar"
+sv_short = "Uppdateringskontroll"
 [instance.content.update.check.title]
 en = "Checking for updates"
 de = "Suche nach Aktualisierungen"
 hu = "Frissítések keresése"
+sv = "Kollar efter uppdateringar"
 [instance.content.update.check.error]
 en = "Error checking for updates"
 de = "Fehler beim suchen nach Aktualisierungen"
 hu = "Hiba a frissítések keresése közben"
+sv = "Fel vid sökandet efter uppdateringar"
 [instance.content.update.check.error_404]
 en = "Error while checking updates - 404 not found"
 de = "Fehler beim suchen nach Aktualisierungen - 404 nicht gefunden"
 hu = "Hiba a frissítések keresése közben - 404 nem található"
+sv = "Fel vid sökandet efter uppdateringar - 404 hittades ej"
 [instance.content.update.check.invalid_hash_error]
 en = "Error while checking updates - returned invalid hash"
 de = "Fehler beim suchen nach Aktualisierungen - falscher hash"
 hu = "Hiba a frissítések keresése közben - helytelen a hash"
+sv = "Fel vid sökandet efter uppdateringar - ogiltig hash"
 [instance.content.update.check.last_up_to_date]
 en = "Up-to-date as of last check"
 de = "Aktuell, Stand letzter Überprüfung"
 hu = "Legutóbbi ellenőrzés óta naprakész"
+sv = "Uppdaterad från senaste kontrollen"
 [instance.content.update.check.up_to_date]
 en = "Up-to-date"
 de = "Aktuell"
 hu = "Naprakész"
+sv = "Senaste"
 [instance.content.update.download.error]
 en = "Error downloading update"
 de = "Fehler beim herunterladen von der Aktuallisierung"
 hu = "Hiba a frissítés letöltése közben"
+sv = "Fel vid nedladdning av uppdatering"
 [instance.content.update.download.from_modrinth]
 en = "Download update from Modrinth"
 de = "Lade Aktuallisierung von Modrinth herunter"
 hu = "Frissítés letöltése a Modrinthről"
+sv = "Ladda ned uppdatering från Modrinth"
 [instance.content.update.download.from_curseforge]
 en = "Download update from Curseforge"
 de = "Lade Aktuallisierung von Curseforge herunter"
 hu = "Frissítés letöltése a Curseforgeról"
+sv = "Ladda ned uppdatering från Curseforge"
 [instance.content.update.error]
 en = "Error updating mod"
 de = "Fehler beim Aktualisieren"
 hu = "Hiba a mod frissítése közben"
+sv = "Fel vid uppdatering av mod"
 [instance.content.update.installed_manually]
 en = "Installed manually - cannot automatically update"
 de = "Manuell installiert – kann nicht automatisch aktualisiert werden"
 hu = "Telepítés egyedileg - nem lehet autómatikusan frissíteni"
+sv = "Installera manuellt - kan inte automatiskt uppdatera"
 
 [instance.sync.label]
 en = "Syncing"
 de = "Synchronisierung"
 hu = "Stinkronizál"
+sv = "Synkar"
 [instance.sync.description]
 en = "These options allow for syncing various files/folders across instances"
 de = "Diese Optionen ermöglichen die Synchronisierung verschiedener Dateien/Ordner über verschiedene Instanzen hinweg"
 hu = "Ezek az opciók megengedik a különböző fájlok/mappák szinkronizálását a példányok között"
+sv = "Dessa alternativ möjliggör synkronisering av olika filer/mappar mellan instanser"
 [instance.sync.open_folder]
 en = "Open synced folders directory"
 de = "Öffne synchronisierte Ordner"
 hu = "Szinkronizált mappák megnyitása"
+sv = "Öppna katalogen för synkroniserade mappar"
 [instance.sync.already_exists]
 en = "${num: usize} instance(s) already contain a '${name: &str}' folder. Please safely backup and remove the folders to enable syncing"
 de = "${num: usize} Instanzen enthalten einen „${name: &str}“ Ordner. Bitte erstelle eine sicherheits Kopie und lösche den Ordner um zu synchronisieren"
 hu = "${num: usize} példány már tartalmazza a(z) '${name: &str}' mappát. Kérlek csinálj biztonsági mentést a mappákról, majd töröld őket, hogy bekapcsolhasd a szinkronizálást"
+sv = "${num: usize} instans(er) innehåller redan en '${name: &str}' mapp. Säkerhetskopiera och ta bort mapparna på ett säkert sätt för att aktivera synkronisering"
 [instance.sync.folders_count]
 en = "(${count: usize}/${total: usize} folders synced)"
 de = "(${count: usize}/${total: usize} Ordner synchronisiert)"
 hu = "(${count: usize}/${total: usize} mappa szinkronizálva)"
+sv = "(${count: usize}/${total: usize} foldrar synkade)"
 [instance.sync.unable_count]
 en = "${count: usize}/${total: usize} instances are unable to be synced!"
 de = "${count: usize}/${total: usize} Instanzen konnten nicht synchronisiert werden!"
 hu = "${count: usize}/${total: usize} példány nem szinkronizálható!"
+sv = "${count: usize}/${total: usize} instanser kan ej synkas!"
 [instance.sync.files]
 en = "Files"
 de = "Dateien"
 hu = "Fájlok"
+sv = "Filer"
 [instance.sync.folders]
 en = "Folders"
 de = "Ordner"
 hu = "Mappák"
+sv = "Foldrar"
 [instance.sync.mods]
 en = "Mods"
 de = "Mods"
 hu = "Modok"
+sv = "Mods"
 [instance.sync.custom]
 en = "Custom"
 de = "Benutzerdefiniert"
 hu = "Egyedi"
+sv = "Användardefinierat"
 [instance.sync.sync_name_file]
 en = "Sync ${name: &str} file"
 de = "Synchronisiere ${name: &str}"
 hu = "${name: &str} fájl szinkronizálása"
+sv = "Synka ${name: &str} filen"
 [instance.sync.sync_name_folder]
 en = "Sync ${name: &str} folder"
 de = "Synchronisiere ${name: &str}"
 hu = "${name: &str} mappa szinkronizálása"
+sv = "Synka ${name: &str} foldern"
 [instance.sync.sync_file]
 en = "Sync file"
 de = "Synchronisiere Datei"
 hu = "Fájl szinkronizálása"
+sv = "Synka fil"
 [instance.sync.sync_folder]
 en = "Sync folder"
 de = "Synchronisiere Ordner"
 hu = "Mappa szinkronizálása"
+sv = "Synka folder"
 [instance.sync.disable_syncing]
 en = "Disable Instance File Syncing"
 de = "Deaktiviere Datensynchronisierung"
 hu = "Példány fájlok szinkronizálásának kikapcsolása"
+sv = "Stäng av instans fil synkning"
 [instance.sync.targets.options]
 en = "Sync options.txt"
 de = "Synchronisiere options.txt"
 hu = "options.txt szinkronizálása"
+sv = "Synka options.txt"
 [instance.sync.targets.servers]
 en = "Sync servers.dat"
 de = "Synchronisiere servers.dat"
 hu = "server.dat szinkronizálása"
+sv = "Synka server.dat"
 [instance.sync.targets.commands]
 en = "Sync command_history.txt"
 de = "Synchronisiere command_history.txt"
 hu = "command_history.txt szinkronizálása"
+sv = "Synka command_history.txt"
 [instance.sync.targets.hotbars]
 en = "Sync hotbar.nbt"
 de = "Synchronisiere hotbar.nbt"
 hu = "hotbar.nbt szinkronizálása"
+sv = "Synka hotbar.nbt"
 [instance.sync.targets.saves]
 en = "Sync saves folder"
 de = "Synchronisiere Welten Ordner"
 hu = "Világok mappájának szinkronizálása"
+sv = "Synka värld-folder"
 [instance.sync.targets.config]
 en = "Sync config folder"
 de = "Synchronisiere Konfigurationsordner"
 hu = "Konfigurációs mappa szinkronizálása"
+sv = "Synka konfig folder"
 [instance.sync.targets.screenshots]
 en = "Sync screenshots folder"
 de = "Synchronisiere Bildschirmaufnahmen"
 hu = "Képernyőképek mappájának szinkronizálása"
+sv = "Synka skärmsklipps folder"
 [instance.sync.targets.resourcepacks]
 en = "Sync resourcepacks folder"
 de = "Synchronisiere Ressourcenpakete"
 hu = "Forráscsomagok mappájának szinkronizálása"
+sv = "Synka resurspakets folder"
 [instance.sync.targets.shaderpacks]
 en = "Sync shaderpacks folder"
 de = "Synchronisiere Shaderpakete"
 hu = "Shadercsomagok mappájának szinkronizálása"
+sv = "Synka shaderpakets folder"
 [instance.sync.targets.flashback]
 en = "Sync Flashback (flashback) folder"
 de = "Synchronisiere Flashback Ordner (flashback)"
 hu = "Flashback (flashback) mappájának szinkronizálása"
+sv = "Synka Flashback (flashback) folder"
 [instance.sync.targets.dh]
 en = "Sync Distant Horizons (Distant_Horizons_server_data) folder"
 de = "Synchronisiere Distant Horizons (Distant_Horizons_server_data) Ordner"
 hu = "Distant Horizons (Distant_Horizons_server_data) mappájának szinkronizálása"
+sv = "Synka Distant Horizons (Distant_Horizons_server_data) folder"
 [instance.sync.targets.voxy]
 en = "Sync Voxy (.voxy) folder"
 de = "Synchronisiere Voxy Ordner (.voxy)"
 hu = "Voxy (.voxy) mappájának szinkronizálása"
+sv = "Synka Voxy (.voxy) folder"
 [instance.sync.targets.xaero]
 en = "Sync Xaero's Minimap (xaero) folder"
 de = "Synchronisiere Xaero's Minimap Ordner (xaero)"
 hu = "Xaero's Minimap (xaero) mappájának szinkronizálása"
+sv = "Synka Xaero's Minimap (xaero) folder"
 [instance.sync.targets.journeymap]
 en = "Sync Journeymap (journeymap) folder"
 de = "Synchronisiere Journeymap Ordner (journeymap)"
 hu = "Journeymap (journeymap) mappájának szinkronizálása"
+sv = "Synka Journeymap (journeymap) folder"
 [instance.sync.targets.bobby]
 en = "Sync Bobby (.bobby) folder"
 de = "Synchronisiere Bobby Ordner (.bobby)"
 hu = "Bobby (.bobby) mappájának szinkronizálása"
+sv = "Synka Bobby (.bobby) folder"
 [instance.sync.targets.litematic]
 en = "Sync Litematic (schematic) folder"
 de = "Synchronisiere Litematic Ordner (schematic)"
 hu = "Litematic (schematic) mappájának szinkronizálása"
+sv = "Synka Litematic (schematic) folder"
 
 [settings.title]
 en = "Settings"
 de = "Einstellungen"
 hu = "Beállítások"
+sv = "Inställningar"
 [settings.interface]
 en = "Interface"
 de = "Benutzeroberfläche"
 hu = "Felület"
+sv = "Gränsnitt"
 [settings.network]
 en = "Network"
 de = "Netzwerk"
 hu = "Hálózat"
+sv = "Nätvärk"
 [settings.theme.title]
 en = "Theme"
 de = "Farbschema"
 hu = "Téma"
+sv = "Tema"
 [settings.theme.open_folder]
 en = "Open theme folder"
 de = "Öffne Farbschema Ordner"
 hu = "Téma mappa megnyitása"
+sv = "Öppna tema folder"
 [settings.theme.open_repo]
 en = "Open theme repository"
 de = "Öffne Farbschema Repository"
 hu = "Téma repository megnyitása"
+sv = "Öppna tema git-repo"
+
 [settings.delete.title]
 en = "Deletion"
 de = "Löschung"
 hu = "Törlés"
+sv = "Radering"
 [settings.delete.skip_mod_delete_confirmation]
 en = "Shift+Click to skip mod delete confirmation"
 de = "Shift+Klick um Mod-Löschungsbestätigung zu überspringen"
 hu = "Shift+Katt a mod törlésének megerősítésének az átlépéséhez"
+sv = "Shift-klicka för att skippa mod raderingskonfirmation"
 [settings.delete.skip_instance_delete_confirmation]
 en = "Shift+Click to skip instance delete confirmation"
 de = "Shift+Klick um Instanz-Löschungsbestätigung zu überspringen"
 hu = "Shift+Katt a példány törlésének megerősítésének az átlépéséhez"
+sv = "Shift-klicka för att skippa instans raderingskonfirmation"
 [settings.windows.title]
 en = "Windows"
 de = "Fenster"
 hu = "Ablakok"
+sv = "Fönster"
 [settings.windows.hide_main_window]
 en = "Hide main window on launch"
 de = "Verstecke Hauptfenster beim Start"
 hu = "Fő ablak elrejtése a játék indításakor"
+sv = "Göm huvudfönstret vid spelstart"
 [settings.windows.open_game_output]
 en = "Open game output on launch"
 de = "Öffne Spiel Ausgabe beim Start"
 hu = "Játéknapló megnyitása a játék indításakor"
+sv = "Öppna spelutdata vid spelstart"
 [settings.windows.close_all_when_main_closed]
 en = "Close all other windows when main window closed"
 de = "Schließe alle anderen Fenster when das Hauptfenster geschlossen ist"
 hu = "Minden másik ablak bezárása a fő ablak bezárásakor"
+sv = "Stäng alla andra fönster när huvudfönstret stängs"
 [settings.windows.use_os_titlebar]
+# Does this work on windows/macos?
 en = "Use OS titlebar (requires restart)"
+sv = "Använd operativsystemets titlebar (kräver omstart)"
 [settings.privacy.title]
 en = "Privacy"
 de = "Privatsphäre"
 hu = "Adatvédelem"
+sv = "Integritet"
 [settings.privacy.hide_usernames]
 en = "Hide usernames"
 de = "Verstecke Nutzernamen"
 hu = "Felhasználónevek elrejtése"
+sv = "Göm användarnamn"
 [settings.privacy.hide_skins]
 en = "Hide skins"
 de = "Verstecke Skins"
 hu = "Kinézetek elrejtése"
+sv = "Göm skinn"
 [settings.privacy.hide_server_addresses]
 en = "Hide server addresses"
 de = "Verstecke Server Adresse"
 hu = "Szerverek címének elrejtése"
+sv = "Göm server addresser"
 [settings.proxy.title]
 en = "Proxy Settings"
 de = "Proxy Einstellung"
 hu = "Proxy beállítások"
+sv = "Proxy inställningar"
 [settings.proxy.enabled]
 en = "Enable Proxy"
 de = "Aktiviere Proxy"
 hu = "Proxy engedélyezése"
+sv = "Aktivira Proxy"
 [settings.proxy.protocol]
 en = "Protocol"
 de = "Protokoll"
 hu = "Protokoll"
+sv = "Protokoll"
 [settings.proxy.host]
 en = "Host"
 de = "Host"
 hu = "Kiszolgáló"
+sv = "Host"
 [settings.proxy.port]
 en = "Port"
 de = "Port"
 hu = "Port"
+sv = "Port"
 [settings.proxy.auth]
 en = "Authentication"
 de = "Authentifizierung"
 hu = "Hitelesítés"
+sv = "Autentisering"
 [settings.proxy.use_auth]
 en = "Use Authentication"
 de = "Nutze Authentifizierung"
 hu = "Hitelesítés használata"
+sv = "Använd autentisering"
 [settings.proxy.username]
 en = "Username"
 de = "Nutzername"
 hu = "Felhasználónév"
+sv = "Användarnamn"
 [settings.proxy.password]
 en = "Password"
 de = "Passwort"
 hu = "Jelszó"
+sv = "Lösenord"
 [settings.proxy.launcher_only_note]
 en = "Note - Proxy settings only apply to the launcher, not the game itself"
 de = "Achtung - Proxyeinstellungen sind nur für Pandora, nicht für Minecraft"
 hu = "Megjegyzés - A proxy beállítások csak az indítóra hatnak, nem a játékra"
+sv = "Observera - Proxy inställningar gäller endast för launchern inte för själva spelet"
 
 [skins.title]
 en = "Skins"
 de = "Skins"
 hu = "Kinézetek"
+sv = "Skinn"
 [skins.capes]
 en = "Capes"
 de = "Umhänge"
 hu = "Köpenyek"
+sv = "Mantlar"
 [skins.login_to_view_edit]
 en = "Login to view/edit ${username: &str}'s skin"
 de = "Einloggen um ${username: &str}s Skin anzusehen/bearbeiten"
 hu = "Jelentkezz be, hogy megnézd/szerkeszd ${username: &str} kinézeteit"
+sv = "Logga-in för att visa/redigera ${username: &str}s skin"
 [skins.unable_to_load]
 en = "Unable to load ${username: &str}'s skin"
 de = "Konnte ${username: &str}s Skin nicht laden"
 hu = "Nem sikerült betölteni ${username: &str} kinézeteit"
+sv = "Kunde ej ladda ${username: &str}s skinn"
 [skins.loading]
 en = "Loading ${username: &str}'s skin..."
 de = "Lade ${username: &str}s Skin..."
 hu = "${username: &str} kinézeteinek betöltése..."
+sv = "Laddar ${username: &str}s skinn..."
 [skins.no_offline]
 en = "Skins cannot be applied to offline accounts"
 de = "Skins können nicht auf Offline Konte angewant werden"
 hu = "Nem alkalmazhatóak kinézetek offline fiókokra"
+sv = "Skins kan inte tillämpas på offline-konton"
 [skins.add_from_file]
 en = "Add from file"
 de = "Füge von Datei hinzu"
 hu = "Hozzáadás fájlból"
+sv = "Lägg till från fil"
 [skins.select_skin]
 en = "Select Skin"
 de = "Wähle ein Skin aus"
 hu = "Válassz egy kinézetet"
+sv = "Välj ett skinn"
 [skins.copy_from_player]
 en = "Copy from player"
 de = "Von Spieler kopieren"
 hu = "Másolás egy játékosról"
+sv = "Kopiera från spelare"
 [skins.copy]
 en = "Copy"
 de = "Kopiern"
 hu = "Másolás"
+sv = "Kopiera"
 [skins.add_from_url]
 en = "Add from url"
 de = "Von URL hinzufügen"
@@ -1641,31 +2056,39 @@ hu = "Hozzáadás linkről"
 en = "Download"
 de = "Herunterladen"
 hu = "Letöltés"
+sv = "Ladda-ned"
 [skins.open_folder]
 en = "Open folder"
 de = "Öffne Ordner"
 hu = "Mappa megnyitása"
+sv = "Öppna folder"
 [skins.switch_view.texture]
 en = "Switch to texture"
 de = "Wechle zu Textur"
 hu = "Váltás a textúrára"
+sv = "Byt till textur"
 [skins.switch_view.model]
 en = "Switch to model"
 de = "Wechsle zu Model"
 hu = "Váltás a modellre"
+sv = "Byt till model"
 [login.title]
 en = "Login"
 de = "Einloggen"
 hu = "Bejelentkezés"
+sv = "Logga in"
 [login.error]
 en = "Error while logging in"
 de = "Fehler beim einloggen"
 hu = "Hiba történt bejelentkezés közben"
+sv = "Fel vid inloggningen"
 [import.disabled]
 en = "Please select one of the above to import from ${launcher: &str}"
 de = "Bitte wähle etwas oben aus um es von ${launcher: &str} zu importieren"
 hu = "Kérlek válassz egyet a fentiek közül, hogy importálj innen: ${launcher: &str}"
+sv = "Var vänlig och välj något av de ovanstående för att importera från ${launcher: &str}"
 [import.enabled]
 en = "Import the above selected from ${launcher: &str}"
 de = "Importiere das oben ausgewählte von ${launcher: &str}"
 hu = "A fentiek közül kiválasztottak importálása innen: ${launcher: &str}"
+sv = "Importera det valda ovanstående från ${launcher: &str}"

--- a/crates/t/src/lib.rs
+++ b/crates/t/src/lib.rs
@@ -7,11 +7,13 @@ pub fn set_lang(name: &str) {
 		"en" => 0,
 		"de" => 1,
 		"hu" => 2,
+		"sv" => 3,
 		_ => panic!("Unknown language: {name}"),
 	};
 	LANG.store(id, std::sync::atomic::Ordering::Relaxed);
 }
 
+#[rustfmt::skip]
 pub mod account {
     pub fn get(key: &str) -> Option<&'static str> {
         match key {
@@ -24,6 +26,7 @@ pub mod account {
             _ => None,
         }
     }
+    #[rustfmt::skip]
     pub mod add {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {
@@ -39,6 +42,7 @@ pub mod account {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Fehler beim Konto hinzufügen",
                 2 => "Hiba történt a fiók hozzáadásakor",
+                3 => "Kunde ej lägga till konto",
                 _ => "Error adding account",
             }
         }
@@ -46,6 +50,7 @@ pub mod account {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Konto hinzufügen",
                 2 => "Fiók hozzáadása",
+                3 => "Lägg till konto",
                 _ => "Add account",
             }
         }
@@ -53,6 +58,7 @@ pub mod account {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Offline Konto hinzufügen",
                 2 => "Offline fiók hozzáadása",
+                3 => "Lägg till offline-konto",
                 _ => "Add Offline Account",
             }
         }
@@ -60,6 +66,7 @@ pub mod account {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Hinzufügen",
                 2 => "Hozzáadás",
+                3 => "Lägg till",
                 _ => "Add",
             }
         }
@@ -67,6 +74,7 @@ pub mod account {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Füge neues Konto hinzu",
                 2 => "Másik fiók hozzáadása",
+                3 => "Lägger till nytt konto",
                 _ => "Adding new account",
             }
         }
@@ -75,6 +83,7 @@ pub mod account {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Name",
             2 => "Név",
+            3 => "Namn",
             _ => "Name",
         }
     }
@@ -82,6 +91,7 @@ pub mod account {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Kein Konto",
             2 => "Nincs fiók",
+            3 => "Inget Konto",
             _ => "No Account",
         }
     }
@@ -89,6 +99,7 @@ pub mod account {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Konto Überschreiben",
             2 => "Fiók felülírása",
+            3 => "Åsidosätt Konto",
             _ => "Override Account",
         }
     }
@@ -96,6 +107,7 @@ pub mod account {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Konten",
             2 => "Fiókok",
+            3 => "Konton",
             _ => "Accounts",
         }
     }
@@ -103,6 +115,7 @@ pub mod account {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "UUID",
             2 => "UUID",
+            3 => "UUID",
             _ => "UUID",
         }
     }
@@ -110,10 +123,12 @@ pub mod account {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Zufällig",
             2 => "Random",
+            3 => "Random",
             _ => "Random",
         }
     }
 }
+#[rustfmt::skip]
 pub mod common {
     pub fn get(key: &str) -> Option<&'static str> {
         match key {
@@ -140,6 +155,7 @@ pub mod common {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Pandora",
             2 => "Pandora",
+            3 => "Pandora",
             _ => "Pandora",
         }
     }
@@ -147,6 +163,7 @@ pub mod common {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Veränderungen anwenden",
             2 => "Változtatások alkalmazása",
+            3 => "Applicera förändringarna",
             _ => "Apply Changes",
         }
     }
@@ -154,6 +171,7 @@ pub mod common {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Abbrechen",
             2 => "Mégsem",
+            3 => "Ångra",
             _ => "Cancel",
         }
     }
@@ -161,6 +179,7 @@ pub mod common {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Benutzerdefiniert",
             2 => "Egyedi",
+            3 => "Specialgjord",
             _ => "Custom",
         }
     }
@@ -168,6 +187,7 @@ pub mod common {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Fehler",
             2 => "Hiba",
+            3 => "Error",
             _ => "Error",
         }
     }
@@ -175,6 +195,7 @@ pub mod common {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Bild",
             2 => "Ikon",
+            3 => "Ikon",
             _ => "Icon",
         }
     }
@@ -182,9 +203,11 @@ pub mod common {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Neuste",
             2 => "Legújabb",
+            3 => "Nyast",
             _ => "Latest",
         }
     }
+    #[rustfmt::skip]
     pub mod layout {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {
@@ -197,6 +220,7 @@ pub mod common {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Karten",
                 2 => "Kártyák",
+                3 => "Kort",
                 _ => "Cards",
             }
         }
@@ -204,6 +228,7 @@ pub mod common {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Liste",
                 2 => "Lista",
+                3 => "Lista",
                 _ => "List",
             }
         }
@@ -212,6 +237,7 @@ pub mod common {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Maximum",
             2 => "Maximum",
+            3 => "Max",
             _ => "Max",
         }
     }
@@ -219,9 +245,11 @@ pub mod common {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Minimum",
             2 => "Minimum",
+            3 => "Minst",
             _ => "Min",
         }
     }
+    #[rustfmt::skip]
     pub mod nav {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {
@@ -234,6 +262,7 @@ pub mod common {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Nach Unten",
                 2 => "Ugrás allulra",
+                3 => "Gå till Botten",
                 _ => "Go to Bottom",
             }
         }
@@ -241,6 +270,7 @@ pub mod common {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Nach Oben",
                 2 => "Ugrás felülre",
+                3 => "Gå till Toppen",
                 _ => "Go to Top",
             }
         }
@@ -249,6 +279,7 @@ pub mod common {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "OK",
             2 => "OK",
+            3 => "OK",
             _ => "OK",
         }
     }
@@ -256,6 +287,7 @@ pub mod common {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "ODER",
             2 => "VAGY",
+            3 => "ELLER",
             _ => "OR",
         }
     }
@@ -263,6 +295,7 @@ pub mod common {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Zurücksetzen",
             2 => "Visszaállít",
+            3 => "Återställ",
             _ => "Reset",
         }
     }
@@ -270,6 +303,7 @@ pub mod common {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Suche",
             2 => "Keresés",
+            3 => "Sök",
             _ => "Search",
         }
     }
@@ -277,6 +311,7 @@ pub mod common {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Unbekannt",
             2 => "Ismeretlen",
+            3 => "Okänd",
             _ => "Unknown",
         }
     }
@@ -284,6 +319,7 @@ pub mod common {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "<ungesetzt>",
             2 => "<nincs megadva>",
+            3 => "<avaktivera>",
             _ => "<unset>",
         }
     }
@@ -291,10 +327,12 @@ pub mod common {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Aktualisiert",
             2 => "Frissítés",
+            3 => "Uppdatera",
             _ => "Update",
         }
     }
 }
+#[rustfmt::skip]
 pub mod curseforge {
     pub fn get(key: &str) -> Option<&'static str> {
         match key {
@@ -306,9 +344,11 @@ pub mod curseforge {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Curseforge",
             2 => "Curseforge",
+            3 => "Curseforge",
             _ => "Curseforge",
         }
     }
+    #[rustfmt::skip]
     pub mod sort {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {
@@ -324,6 +364,7 @@ pub mod curseforge {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Autor",
                 2 => "Készítő",
+                3 => "Skapare",
                 _ => "Author",
             }
         }
@@ -331,6 +372,7 @@ pub mod curseforge {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Downloads",
                 2 => "Letöltések",
+                3 => "Nedladdningar",
                 _ => "Downloads",
             }
         }
@@ -338,6 +380,7 @@ pub mod curseforge {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Name",
                 2 => "Név",
+                3 => "Namn",
                 _ => "Name",
             }
         }
@@ -345,6 +388,7 @@ pub mod curseforge {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Popularität",
                 2 => "Népszerűség",
+                3 => "Populäritet",
                 _ => "Popularity",
             }
         }
@@ -352,12 +396,15 @@ pub mod curseforge {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Aktualisiert",
                 2 => "Frissítve",
+                3 => "Uppdaterat",
                 _ => "Updated",
             }
         }
     }
 }
+#[rustfmt::skip]
 pub mod file_system {
+    #[rustfmt::skip]
     pub mod open_folder {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {
@@ -369,6 +416,7 @@ pub mod file_system {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => format!("Konnte Ordner nicht öffnen: {err}"),
                 2 => format!("Nem sikerült megnyitni a mappát: {err}"),
+                3 => format!("Kunde ej öppan folderna: {err}"),
                 _ => format!("Unable to open folder: {err}"),
             }
         }
@@ -376,16 +424,19 @@ pub mod file_system {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Konnte Ordner nicht öffnen: ist kein Ordner",
                 2 => "Nem sikerült megnyitni a mappát: nem egy mappa",
+                3 => "Kunde ej öppna foldern: inte en katalog",
                 _ => "Unable to open folder: not a directory",
             }
         }
     }
 }
+#[rustfmt::skip]
 pub mod import {
     pub fn disabled(launcher: &str) -> String {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => format!("Bitte wähle etwas oben aus um es von {launcher} zu importieren"),
             2 => format!("Kérlek válassz egyet a fentiek közül, hogy importálj innen: {launcher}"),
+            3 => format!("Var vänlig och välj något av de ovanstående för att importera från {launcher}"),
             _ => format!("Please select one of the above to import from {launcher}"),
         }
     }
@@ -393,10 +444,12 @@ pub mod import {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => format!("Importiere das oben ausgewählte von {launcher}"),
             2 => format!("A fentiek közül kiválasztottak importálása innen: {launcher}"),
+            3 => format!("Importera det valda ovanstående från {launcher}"),
             _ => format!("Import the above selected from {launcher}"),
         }
     }
 }
+#[rustfmt::skip]
 pub mod instance {
     pub fn get(key: &str) -> Option<&'static str> {
         match key {
@@ -445,6 +498,7 @@ pub mod instance {
             _ => None,
         }
     }
+    #[rustfmt::skip]
     pub mod content {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {
@@ -469,6 +523,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => format!("von {name}"),
                 2 => format!("tőle: {name}"),
+                3 => format!("av {name}"),
                 _ => format!("by {name}"),
             }
         }
@@ -476,14 +531,17 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Kategorien",
                 2 => "Kategóriák",
+                3 => "Kategorier",
                 _ => "Categories",
             }
         }
+        #[rustfmt::skip]
         pub mod downloads {
             pub fn b(num: f64) -> String {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => format!("{num}Mrd. Downloads"),
                     2 => format!("{num}Mrd letöltés"),
+                    3 => format!("{num}md Nedladdningar"),
                     _ => format!("{num}B Downloads"),
                 }
             }
@@ -491,6 +549,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => format!("{num}Tsd. Downloads"),
                     2 => format!("{num}E letöltés"),
+                    3 => format!("{num}k Nedladdningar"),
                     _ => format!("{num}K Downloads"),
                 }
             }
@@ -498,6 +557,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => format!("{num}Mil. Downloads"),
                     2 => format!("{num}M letöltés"),
+                    3 => format!("{num}mn Nedladdningar"),
                     _ => format!("{num}M Downloads"),
                 }
             }
@@ -505,6 +565,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => format!("{num} Downloads"),
                     2 => format!("{num} letöltés"),
+                    3 => format!("{num} Nedladdningar"),
                     _ => format!("{num} Downloads"),
                 }
             }
@@ -513,6 +574,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Fehler beim laden vom Projekt",
                 2 => "Hiba a projekt betöltésekor",
+                3 => "Fel vid laddning av projekt",
                 _ => "Error loading project",
             }
         }
@@ -520,9 +582,11 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Dateiname: ",
                 2 => "Fájlnév: ",
+                3 => "Filnamn: ",
                 _ => "Filename: ",
             }
         }
+        #[rustfmt::skip]
         pub mod install {
             pub fn get(key: &str) -> Option<&'static str> {
                 match key {
@@ -554,6 +618,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Zu Instanz hinzufügen",
                     2 => "Hpzzáadás a példányhoz",
+                    3 => "Lägg till i instans",
                     _ => "Add to instance",
                 }
             }
@@ -561,6 +626,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Installiert immer die neuste Version. Deaktivieren um ältere Versionen installieren zu können",
                     2 => "Mindíg a legújabb telepítése. Szedd ki a pipát, hogy régebbi verziót tudj telepíteni",
+                    3 => "Installera alltid den senaste versionen. Avmarkera om du vill kunna välja äldre versioner av innehåll att installera.",
                     _ => "Always install the latest version. Untick to be able to choose older versions of content to install",
                 }
             }
@@ -568,6 +634,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Fehler beim installieren von Inhalt",
                     2 => "Hiba a tartalom telepítésekor",
+                    3 => "Fel vid installation av innehåll",
                     _ => "Error installing content",
                 }
             }
@@ -575,6 +642,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Von Curseforge hinzufügen",
                     2 => "Hozzáadás Curseforgeról",
+                    3 => "Lägg till från Curseforge",
                     _ => "Add from Curseforge",
                 }
             }
@@ -582,6 +650,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Von Datei hinzufügen",
                     2 => "Hozzáadás fájlból",
+                    3 => "Lägg till från fil",
                     _ => "Add from file",
                 }
             }
@@ -589,6 +658,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Von Modrinth hinzufügen",
                     2 => "Hozzáadás Modrinthről",
+                    3 => "Lägg till från Modrinth",
                     _ => "Add from Modrinth",
                 }
             }
@@ -596,6 +666,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => format!("Installiere {num} Abhängigkeiten"),
                     2 => format!("{num} függőség telepítés"),
+                    3 => format!("Installera {num} beroenden"),
                     _ => format!("Install {num} dependencies"),
                 }
             }
@@ -603,6 +674,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Installiere 1 Abhängigkeit",
                     2 => "1 függőség telepítése",
+                    3 => "Installera 1 beroende",
                     _ => "Install 1 dependency",
                 }
             }
@@ -610,6 +682,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Invalieder/Gefährlicher Dateinname",
                     2 => "Érvénytelen/veszélyes fájlnév",
+                    3 => "Ogilgit/farligt filnamn",
                     _ => "Invalid/dangerous filename",
                 }
             }
@@ -617,6 +690,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Installieren",
                     2 => "Telepítés",
+                    3 => "Installera",
                     _ => "Install",
                 }
             }
@@ -624,6 +698,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Installiere neuste Version",
                     2 => "Legújabb telepítése",
+                    3 => "Installerar nyaste",
                     _ => "Install Latest",
                 }
             }
@@ -631,9 +706,11 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Fehlender sha1 Hash",
                     2 => "Hiányzik az sha1 hash",
+                    3 => "saknad sha1-hash",
                     _ => "Missing sha1 hash",
                 }
             }
+            #[rustfmt::skip]
             pub mod new_instance_with {
                 pub fn get(key: &str) -> Option<&'static str> {
                     match key {
@@ -649,6 +726,7 @@ pub mod instance {
                     match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                         1 => "Erstelle eine neue Instanz mit dieser Datei",
                         2 => "Új példány létrehozása ezzel a fájllal",
+                        3 => "Skapa en ny instans med denna fil",
                         _ => "Create new instance with this file",
                     }
                 }
@@ -656,6 +734,7 @@ pub mod instance {
                     match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                         1 => "Erstelle neue Instanz mit dieser Mod",
                         2 => "Új példány létrehozása ezzel a moddal",
+                        3 => "Skapa en ny instans med detta mod",
                         _ => "Create new instance with this mod",
                     }
                 }
@@ -663,6 +742,7 @@ pub mod instance {
                     match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                         1 => "Erstelle eine neue Instanz mit diesem Modpaket",
                         2 => "Új példány létrehozása ezzel a modcsomaggal",
+                        3 => "Skapa en ny instans med detta modpacket",
                         _ => "Create new instance with this modpack",
                     }
                 }
@@ -670,6 +750,7 @@ pub mod instance {
                     match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                         1 => "Erstelle eine neue Instanz mit diesem Ressourcenpaket",
                         2 => "Új példány létrehozása ezzel a forráscsomaggal",
+                        3 => "Skapa en ny instans med detta resurspacket",
                         _ => "Create new instance with this resourcepack",
                     }
                 }
@@ -677,6 +758,7 @@ pub mod instance {
                     match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                         1 => "Erstelle eine neue Instanz mit diesem Shader",
                         2 => "Új példány létrehozása ezzel a shaderrel",
+                        3 => "Skapa en ny instans med denna shader",
                         _ => "Create new instance with this shader",
                     }
                 }
@@ -685,6 +767,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Es konnte keine passende Version des Projekts gefunden werden",
                     2 => "Nem található egyező projekt verzió",
+                    3 => "Kunde ej hitta matchande version av projekt",
                     _ => "Unable to find matching version of project",
                 }
             }
@@ -692,6 +775,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Keine Modversion ausgewählt",
                     2 => "Nincs kiválasztva mod verzió",
+                    3 => "Igen mod-version vald",
                     _ => "No mod version selected",
                 }
             }
@@ -699,6 +783,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Der Mod Autor hat das herunterladen von Drittanbietern blockiert",
                     2 => "A mod készítője letiltotta a harmadik féltől származó indítókon keresztüli letöltéseket",
+                    3 => "Modförfattaren har blockerat nedladdningar från tredjeparts launchers",
                     _ => "The mod author has blocked downloads from third-party launchers",
                 }
             }
@@ -706,6 +791,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Neuinstallieren",
                     2 => "Újratelepítés",
+                    3 => "Ominstallera",
                     _ => "Reinstall",
                 }
             }
@@ -713,6 +799,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Wähle zu installierende Mods aus",
                     2 => "Válaszd ki a telepíteni kívánt modokat",
+                    3 => "Välj mods att installera",
                     _ => "Select mods to install",
                 }
             }
@@ -720,11 +807,13 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Wähle Ressourcenpakete aus um sie zu installieren",
                     2 => "Válaszd ki a telepíteni kívánt forráscsomagokat",
+                    3 => "Välj resurspaket att installera",
                     _ => "Select resource packs to install",
                 }
             }
             pub fn select_shaders() -> &'static str {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
+                    3 => "Välj shaders att installera",
                     _ => "Select shaders to install",
                 }
             }
@@ -732,6 +821,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => format!("Installiere {name}"),
                     2 => format!("{name} telepítése"),
+                    3 => format!("Installera {name}"),
                     _ => format!("Install {name}"),
                 }
             }
@@ -739,6 +829,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Konnte Projekttype „Anderes“ nicht installieren",
                     2 => "Nem lehet telepíteni a 'más' projekt típust",
+                    3 => "Kunde ej installera 'andra' projekt-typ",
                     _ => "Unable to install 'other' project type",
                 }
             }
@@ -746,6 +837,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Konnte Projektart „anderes“ nicht Installieren",
                     2 => "Nem lehet telepíteni a 'más' projekt típust",
+                    3 => "Det gick inte att installera projekttypen 'annan'",
                     _ => "Unable to install 'other' project type",
                 }
             }
@@ -753,10 +845,12 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Keine Ahnung wie man diesem Typ von Inhalt installiert",
                     2 => "Nem lehet kezelni ezt a típúsú tartalmat",
+                    3 => "Vet ej hur man hanterar denna typ av innehåll",
                     _ => "Don't know how to handle this type of content",
                 }
             }
         }
+        #[rustfmt::skip]
         pub mod links {
             pub fn get(key: &str) -> Option<&'static str> {
                 match key {
@@ -771,6 +865,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Discord",
                     2 => "Discord",
+                    3 => "Discord",
                     _ => "Discord",
                 }
             }
@@ -778,6 +873,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Fehler melden",
                     2 => "Hiba jelentések",
+                    3 => "Problem",
                     _ => "Issues",
                 }
             }
@@ -785,6 +881,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Quellcode",
                     2 => "Forrás",
+                    3 => "Källa",
                     _ => "Source",
                 }
             }
@@ -792,11 +889,14 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Wiki",
                     2 => "Wiki",
+                    3 => "Wiki",
                     _ => "Wiki",
                 }
             }
         }
+        #[rustfmt::skip]
         pub mod load {
+            #[rustfmt::skip]
             pub mod versions {
                 pub fn get(key: &str) -> Option<&'static str> {
                     match key {
@@ -809,6 +909,7 @@ pub mod instance {
                     match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                         1 => "Keine Mod Versionen gefunden",
                         2 => "Nem találhatók mod verziók",
+                        3 => "Inga mod versioner hittade",
                         _ => "No mod versions found",
                     }
                 }
@@ -816,6 +917,7 @@ pub mod instance {
                     match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                         1 => format!("Keine Mod Version für {ver} gefunden"),
                         2 => format!("Nem található mod verzió a(z) {ver} verzióhoz"),
+                        3 => format!("Inga mod versioner hittade för {ver}"),
                         _ => format!("No mod versions found for {ver}"),
                     }
                 }
@@ -823,6 +925,7 @@ pub mod instance {
                     match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                         1 => format!("Keine Mod Version für {loader} {ver} gefunden"),
                         2 => format!("Nem található verzió a(z) {loader} {ver} loaderhez"),
+                        3 => format!("Inga mod versioner hittade för {loader} {ver}"),
                         _ => format!("No mod versions found for {loader} {ver}"),
                     }
                 }
@@ -830,10 +933,12 @@ pub mod instance {
                     match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                         1 => "Lade Mod Versionen...",
                         2 => "Mod verziók betöltése",
+                        3 => "Laddar mod versioner...",
                         _ => "Loading mod versions...",
                     }
                 }
             }
+            #[rustfmt::skip]
             pub mod versions_from_modrinth {
                 pub fn get(key: &str) -> Option<&'static str> {
                     match key {
@@ -845,6 +950,7 @@ pub mod instance {
                     match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                         1 => format!("Fehler beim laden von Projektversionen von Modrinth: {err}"),
                         2 => format!("Hiba a projekt verziók betöltésekor a Modrinthről: {err}"),
+                        3 => format!("Fel vid laddning av projektversioner från Modrinth: {err}"),
                         _ => format!("Error loading project versions from Modrinth: {err}"),
                     }
                 }
@@ -852,6 +958,7 @@ pub mod instance {
                     match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                         1 => "Lade Projektversionen von Modrinth...",
                         2 => "Projekt verziók betöltése a Modrinthről...",
+                        3 => "Laddar projektets versioner från Modrinth",
                         _ => "Loading project versions from Modrinth...",
                     }
                 }
@@ -861,6 +968,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Modpakete",
                 2 => "Modcsomagok",
+                3 => "Modpack",
                 _ => "Modpacks",
             }
         }
@@ -868,6 +976,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Mods",
                 2 => "Modok",
+                3 => "Mods",
                 _ => "Mods",
             }
         }
@@ -875,6 +984,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Keine Beschreibung",
                 2 => "Nincs leírás",
+                3 => "Igen beskrivning",
                 _ => "No Description",
             }
         }
@@ -882,6 +992,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Keine Bilder",
                 2 => "Nincsnek galéria képek",
+                3 => "Inget bildgalleri",
                 _ => "No gallery images",
             }
         }
@@ -889,6 +1000,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Öffne Seite",
                 2 => "Oldal megnyitása",
+                3 => "Öppna sida",
                 _ => "Open Page",
             }
         }
@@ -896,6 +1008,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Fehler beim Abrufen von Modrinth",
                 2 => "Hiba a Modrinth lekérése közben",
+                3 => "Fel vid hämtning från Modrinth",
                 _ => "Error requesting from Modrinth",
             }
         }
@@ -903,9 +1016,11 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Ressourcenpakete",
                 2 => "Forráscsomagok",
+                3 => "Resurspacket",
                 _ => "Resourcepacks",
             }
         }
+        #[rustfmt::skip]
         pub mod search {
             pub fn get(key: &str) -> Option<&'static str> {
                 match key {
@@ -921,6 +1036,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Suche...",
                     2 => "Keresés...",
+                    3 => "Sök...",
                     _ => "Search...",
                 }
             }
@@ -928,6 +1044,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Suche Mods...",
                     2 => "Modok keresése...",
+                    3 => "Sök Mods...",
                     _ => "Search mods...",
                 }
             }
@@ -935,6 +1052,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Suche Modpakete...",
                     2 => "Modcsomagok keresése...",
+                    3 => "Sök modpacks...",
                     _ => "Search modpacks...",
                 }
             }
@@ -942,6 +1060,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Suche Ressourcenpakete...",
                     2 => "Forráscsomagok keresése...",
+                    3 => "Sök resurspaket...",
                     _ => "Search resourcepacks...",
                 }
             }
@@ -949,6 +1068,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Suche Shader...",
                     2 => "Shaderek keresése...",
+                    3 => "Sök shaders...",
                     _ => "Search shaders...",
                 }
             }
@@ -957,6 +1077,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Shaders",
                 2 => "Shaderek",
+                3 => "Shaders",
                 _ => "Shaders",
             }
         }
@@ -964,9 +1085,11 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Sortieren nach",
                 2 => "Rendszerezés",
+                3 => "Sortera efter",
                 _ => "Sort by",
             }
         }
+        #[rustfmt::skip]
         pub mod tabs {
             pub fn get(key: &str) -> Option<&'static str> {
                 match key {
@@ -979,6 +1102,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Beschreibung",
                     2 => "Leírás",
+                    3 => "Beskrivning",
                     _ => "Description",
                 }
             }
@@ -986,6 +1110,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Gallerie",
                     2 => "Galéria",
+                    3 => "Galleri",
                     _ => "Gallery",
                 }
             }
@@ -994,6 +1119,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Inhalt",
                 2 => "Tartalom",
+                3 => "Innehåll",
                 _ => "Content",
             }
         }
@@ -1001,9 +1127,11 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Unbenannt",
                 2 => "Névtelen",
+                3 => "Namnlös",
                 _ => "Unnamed",
             }
         }
+        #[rustfmt::skip]
         pub mod update {
             pub fn get(key: &str) -> Option<&'static str> {
                 match key {
@@ -1013,6 +1141,7 @@ pub mod instance {
                     _ => None,
                 }
             }
+            #[rustfmt::skip]
             pub mod check {
                 pub fn get(key: &str, short: bool) -> Option<&'static str> {
                     match key {
@@ -1030,6 +1159,7 @@ pub mod instance {
                     match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                         1 => "Fehler beim suchen nach Aktualisierungen",
                         2 => "Hiba a frissítések keresése közben",
+                        3 => "Fel vid sökandet efter uppdateringar",
                         _ => "Error checking for updates",
                     }
                 }
@@ -1037,6 +1167,7 @@ pub mod instance {
                     match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                         1 => "Fehler beim suchen nach Aktualisierungen - 404 nicht gefunden",
                         2 => "Hiba a frissítések keresése közben - 404 nem található",
+                        3 => "Fel vid sökandet efter uppdateringar - 404 hittades ej",
                         _ => "Error while checking updates - 404 not found",
                     }
                 }
@@ -1044,6 +1175,7 @@ pub mod instance {
                     match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                         1 => "Fehler beim suchen nach Aktualisierungen - falscher hash",
                         2 => "Hiba a frissítések keresése közben - helytelen a hash",
+                        3 => "Fel vid sökandet efter uppdateringar - ogiltig hash",
                         _ => "Error while checking updates - returned invalid hash",
                     }
                 }
@@ -1051,6 +1183,7 @@ pub mod instance {
                     match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                         1 => if short { "Aktualisierungs Prüfung" } else { "Nach Aktualisieren suchen" },
                         2 => if short { "Frissítés keresése" } else { "Frissítések keresése" },
+                        3 => if short { "Uppdateringskontroll" } else { "Kolla efter uppdateringar" },
                         _ => if short { "Update Check" } else { "Check for updates" },
                     }
                 }
@@ -1058,6 +1191,7 @@ pub mod instance {
                     match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                         1 => "Aktuell, Stand letzter Überprüfung",
                         2 => "Legutóbbi ellenőrzés óta naprakész",
+                        3 => "Uppdaterad från senaste kontrollen",
                         _ => "Up-to-date as of last check",
                     }
                 }
@@ -1065,6 +1199,7 @@ pub mod instance {
                     match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                         1 => "Suche nach Aktualisierungen",
                         2 => "Frissítések keresése",
+                        3 => "Kollar efter uppdateringar",
                         _ => "Checking for updates",
                     }
                 }
@@ -1072,10 +1207,12 @@ pub mod instance {
                     match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                         1 => "Aktuell",
                         2 => "Naprakész",
+                        3 => "Senaste",
                         _ => "Up-to-date",
                     }
                 }
             }
+            #[rustfmt::skip]
             pub mod download {
                 pub fn get(key: &str) -> Option<&'static str> {
                     match key {
@@ -1089,6 +1226,7 @@ pub mod instance {
                     match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                         1 => "Fehler beim herunterladen von der Aktuallisierung",
                         2 => "Hiba a frissítés letöltése közben",
+                        3 => "Fel vid nedladdning av uppdatering",
                         _ => "Error downloading update",
                     }
                 }
@@ -1096,6 +1234,7 @@ pub mod instance {
                     match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                         1 => "Lade Aktuallisierung von Curseforge herunter",
                         2 => "Frissítés letöltése a Curseforgeról",
+                        3 => "Ladda ned uppdatering från Curseforge",
                         _ => "Download update from Curseforge",
                     }
                 }
@@ -1103,6 +1242,7 @@ pub mod instance {
                     match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                         1 => "Lade Aktuallisierung von Modrinth herunter",
                         2 => "Frissítés letöltése a Modrinthről",
+                        3 => "Ladda ned uppdatering från Modrinth",
                         _ => "Download update from Modrinth",
                     }
                 }
@@ -1111,6 +1251,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Fehler beim Aktualisieren",
                     2 => "Hiba a mod frissítése közben",
+                    3 => "Fel vid uppdatering av mod",
                     _ => "Error updating mod",
                 }
             }
@@ -1118,6 +1259,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Manuell installiert – kann nicht automatisch aktualisiert werden",
                     2 => "Telepítés egyedileg - nem lehet autómatikusan frissíteni",
+                    3 => "Installera manuellt - kan inte automatiskt uppdatera",
                     _ => "Installed manually - cannot automatically update",
                 }
             }
@@ -1125,10 +1267,12 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Aktualisieren",
                     2 => "Frissítés",
+                    3 => "Uppdatera",
                     _ => "Update",
                 }
             }
         }
+        #[rustfmt::skip]
         pub mod version {
             pub fn get(key: &str) -> Option<&'static str> {
                 match key {
@@ -1144,6 +1288,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Dateiversion",
                     2 => "File verzió",
+                    3 => "Fil-Version",
                     _ => "File Version",
                 }
             }
@@ -1151,6 +1296,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Mod Version",
                     2 => "Mod verzió",
+                    3 => "Mod-version",
                     _ => "Mod Version",
                 }
             }
@@ -1158,6 +1304,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Modpaket Version",
                     2 => "Modcsomag verzió",
+                    3 => "Modpacks-Version",
                     _ => "Modpack Version",
                 }
             }
@@ -1165,6 +1312,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Paket Version",
                     2 => "Csomag verzió",
+                    3 => "Paket-version",
                     _ => "Pack Version",
                 }
             }
@@ -1172,6 +1320,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Shader Version",
                     2 => "Shader verzió",
+                    3 => "Shader-Version",
                     _ => "Shader Version",
                 }
             }
@@ -1181,6 +1330,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Erstelle Instanz",
             2 => "Példány létrehozása",
+            3 => "Skapa Instans",
             _ => "Create Instance",
         }
     }
@@ -1188,6 +1338,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Verknüpfung erstellen",
             2 => "Gyorsgomb létrehozása",
+            3 => "Skapa en genväg",
             _ => "Create shortcut",
         }
     }
@@ -1195,6 +1346,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Aktuelle Sitzung",
             2 => "Jelenlegi játékmenet",
+            3 => "Nuvarande Session",
             _ => "Current Session",
         }
     }
@@ -1202,9 +1354,11 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Lösche diese Instanz",
             2 => "Ez a példány törlése",
+            3 => "Radera den här instansen",
             _ => "Delete this instance",
         }
     }
+    #[rustfmt::skip]
     pub mod delete_dialog {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {
@@ -1217,6 +1371,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Ich habe die Konsequenzen gelesen und verstanden",
                 2 => "Elolvastam és megértettem a következményeket",
+                3 => "Jag har läst och förstått dessa effekter",
                 _ => "I have read and understand these effects",
             }
         }
@@ -1224,6 +1379,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => format!("Um zu bestätigen gebe „{name}“ ein"),
                 2 => format!("A megerősítéshez írd be, hogy '{name}' az alábbi mezőbe"),
+                3 => format!("Föra att konfirmera, skriv '{name}' i lådan under"),
                 _ => format!("To confirm, type '{name}' in the box below"),
             }
         }
@@ -1231,6 +1387,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Ich möchte diese Instanz löschen",
                 2 => "Törölni akarom ezt a példányt",
+                3 => "Jag vill ta bort instansen",
                 _ => "I want to delete this instance",
             }
         }
@@ -1238,6 +1395,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => format!("Lösche Instanz: {name}"),
                 2 => format!("Példány törlése: {name}"),
+                3 => format!("Radera Instansen: {name}"),
                 _ => format!("Delete Instance: {name}"),
             }
         }
@@ -1245,10 +1403,12 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => format!("Dadurch will die Instanz „{name}“ sowie die zugehörigen Spielstände, Ressourcenpakete, Mods, Konfigurationsdateien und weitere Elemente endgültig gelöscht. Diese Dateien können nicht wiederhergestellt werden."),
                 2 => format!("Ez örökre törölni fogja a(z) '{name}' példányt és a hozzá tartozó mentéseket, forráscsomagokat, konfigurációs fájlokat és másokat. Ezek a fájlok nem lesznek visszaszerezhetőek"),
+                3 => format!("Detta kommer att permanent radera instansen med namn: '{name}' och tillhörande sparade världar, resurspaket, mods, konfigurationsfiler och mer. Dessa filer kommer inte att kunna återställas"),
                 _ => format!("This will permanently delete the '{name}' instance and associated saves, resourcepacks, mods, configuration files, and more. These files will not be recoverable"),
             }
         }
     }
+    #[rustfmt::skip]
     pub mod export {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {
@@ -1277,27 +1437,32 @@ pub mod instance {
         pub fn action() -> &'static str {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 2 => "Export",
+                3 => "Exportera",
                 _ => "Export",
             }
         }
         pub fn author() -> &'static str {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 2 => "Szerző",
+                3 => "Författare",
                 _ => "Author",
             }
         }
         pub fn curseforge_options() -> &'static str {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 2 => "CurseForge beállítások",
+                3 => "CurseForge inställningar",
                 _ => "CurseForge Options",
             }
         }
         pub fn error() -> &'static str {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 2 => "Hiba a példány exportálása közben",
+                3 => "Fel vid export av instans",
                 _ => "Error exporting instance",
             }
         }
+        #[rustfmt::skip]
         pub mod format {
             pub fn get(key: &str) -> Option<&'static str> {
                 match key {
@@ -1311,24 +1476,28 @@ pub mod instance {
             pub fn curseforge() -> &'static str {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     2 => "CurseForge Pack (.zip)",
+                    3 => "CurseForge Pack (.zip)",
                     _ => "CurseForge Pack (.zip)",
                 }
             }
             pub fn label() -> &'static str {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     2 => "Formátum",
+                    3 => "Format",
                     _ => "Format",
                 }
             }
             pub fn modrinth() -> &'static str {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     2 => "Modrinth Pack (.mrpack)",
+                    3 => "Modrinth Pack (.mrpack)",
                     _ => "Modrinth Pack (.mrpack)",
                 }
             }
             pub fn zip() -> &'static str {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     2 => "Példány Zip",
+                    3 => "Instans Zip-fil",
                     _ => "Instance Zip",
                 }
             }
@@ -1336,90 +1505,105 @@ pub mod instance {
         pub fn include_cache() -> &'static str {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 2 => "Gyorsítótár fájlok belefoglalása",
+                3 => "Inkludera Cache filer",
                 _ => "Include cache files",
             }
         }
         pub fn include_configs() -> &'static str {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 2 => "Konfigurációk belefoglalása",
+                3 => "Inkludera konfigurationsfiler",
                 _ => "Include configs",
             }
         }
         pub fn include_logs() -> &'static str {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 2 => "Naplófájlok/összeomlási jelentések belefoglalása",
+                3 => "Inkludera loggar/krashrapporteringar",
                 _ => "Include logs/crash reports",
             }
         }
         pub fn include_mods() -> &'static str {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 2 => "Modok belefoglalása",
+                3 => "Inkludera mods",
                 _ => "Include mods",
             }
         }
         pub fn include_resourcepacks() -> &'static str {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 2 => "forráscsomagok belefoglalása",
+                3 => "Inkludera resurspacket",
                 _ => "Include resourcepacks",
             }
         }
         pub fn include_saves() -> &'static str {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 2 => "Mentések belefoglalása",
+                3 => "Inkludera världar",
                 _ => "Include saves",
             }
         }
         pub fn include_synced() -> &'static str {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 2 => "Szinkronizált mappák belefoglalása",
+                3 => "Inkludera synkade foldrar",
                 _ => "Include synced folders",
             }
         }
         pub fn modrinth_options() -> &'static str {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 2 => "Modrinth beállítások",
+                3 => "Modrinth inställningar",
                 _ => "Modrinth Options",
             }
         }
         pub fn name() -> &'static str {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 2 => "Név",
+                3 => "Namn",
                 _ => "Name",
             }
         }
         pub fn options() -> &'static str {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 2 => "Export beállítások",
+                3 => "Exportera alternativ",
                 _ => "Export Options",
             }
         }
         pub fn progress() -> &'static str {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 2 => "Példány exportálása",
+                3 => "Exporterar instansen",
                 _ => "Exporting instance",
             }
         }
         pub fn recommended_ram() -> &'static str {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 2 => "Ajánlott RAM",
+                3 => "Rekommenderat RAM-minne",
                 _ => "Recommended RAM",
             }
         }
         pub fn summary() -> &'static str {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 2 => "Összegzés",
+                3 => "Sammanfattning",
                 _ => "Summary",
             }
         }
         pub fn title() -> &'static str {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 2 => "Példány exportálása",
+                3 => "Exportera instansen",
                 _ => "Export Instance",
             }
         }
         pub fn version() -> &'static str {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 2 => "Verzió",
+                3 => "version",
                 _ => "Version",
             }
         }
@@ -1428,6 +1612,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Spielversion",
             2 => "Játék verzió",
+            3 => "Spelversion",
             _ => "Game Version",
         }
     }
@@ -1435,6 +1620,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Verwende System GLFW",
             2 => "Rendszer GLFW használata",
+            3 => "Välj systemets GLFW",
             _ => "Use System GLFW",
         }
     }
@@ -1442,6 +1628,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => format!("({num} instanzen waren inkompatiebel)"),
             2 => format!("({num} példány nem kompatibilis"),
+            3 => format!("({num} instanserna var okompatibla"),
             _ => format!("({num} instances were incompatible)"),
         }
     }
@@ -1449,6 +1636,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Instanzname",
             2 => "Példány neve",
+            3 => "Instans namn",
             _ => "Instance name",
         }
     }
@@ -1456,6 +1644,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Invalieder Name",
             2 => "Érvénytelen név",
+            3 => "Ogiltigt namn",
             _ => "Invalid name",
         }
     }
@@ -1463,6 +1652,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Überschreibe JVM Binary",
             2 => "JVM Binary felülírása",
+            3 => "Överskrid JVM programfil",
             _ => "Override JVM Binary",
         }
     }
@@ -1470,6 +1660,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Fügen JVM Argumente hinzu",
             2 => "JVM argumentumok hozzáadása",
+            3 => "Lägg till JVM-argument",
             _ => "Add JVM Flags",
         }
     }
@@ -1477,6 +1668,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Stoppen",
             2 => "Leállítás",
+            3 => "Stoppa",
             _ => "Kill",
         }
     }
@@ -1484,6 +1676,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Stope Instanz",
             2 => "Példány leállítása",
+            3 => "Stoppa instansen",
             _ => "Kill Instance",
         }
     }
@@ -1491,9 +1684,11 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Instanz",
             2 => "Példány",
+            3 => "Instans",
             _ => "Instance",
         }
     }
+    #[rustfmt::skip]
     pub mod linux {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {
@@ -1509,6 +1704,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "GL-Thread-Optimierungen deaktivieren",
                 2 => "GL-Thread-Optimizációk kikapcsolása",
+                3 => "Inaktivera GL-trådade optimeringar",
                 _ => "Disable GL Threaded Optimizations",
             }
         }
@@ -1516,6 +1712,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Linux Performance",
                 2 => "Linux teljesítmény",
+                3 => "Linux Prestanda",
                 _ => "Linux Performance",
             }
         }
@@ -1523,6 +1720,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Diskrete GPU verwenden",
                 2 => "Diszkrét GPU használata",
+                3 => "Använd diskret grafikkort",
                 _ => "Use Discrete GPU",
             }
         }
@@ -1530,6 +1728,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Nutze GameMode",
                 2 => "GameMode használata",
+                3 => "Använd GameMode",
                 _ => "Use GameMode",
             }
         }
@@ -1537,6 +1736,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Nutze MangoHud",
                 2 => "MangoHud használata",
+                3 => "Använd MangoHud",
                 _ => "Use MangoHud",
             }
         }
@@ -1545,6 +1745,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Loader",
             2 => "Betöltő",
+            3 => "Loader",
             _ => "Loader",
         }
     }
@@ -1552,9 +1753,11 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => format!("{loader} Version"),
             2 => format!("{loader} Verzió"),
+            3 => format!("{loader} Version"),
             _ => format!("{loader} Version"),
         }
     }
+    #[rustfmt::skip]
     pub mod logs {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {
@@ -1565,11 +1768,13 @@ pub mod instance {
                 _ => None,
             }
         }
+        #[rustfmt::skip]
         pub mod cleanup {
             pub fn bytes(num: usize) -> String {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => format!("Räume alte Protokolle auf ({num} bytes)"),
                     2 => format!("Régi naplófájlok tisztítása ({num} byte)"),
+                    3 => format!("Städa upp gamla logg-filer ({num} bytes)"),
                     _ => format!("Cleanup old log files ({num} bytes)"),
                 }
             }
@@ -1577,6 +1782,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => format!("Räume alte Protokolle auf ({num}GB)"),
                     2 => format!("Régi naplófájlok tisztítása ({num}GB)"),
+                    3 => format!("Städa upp gamla logg-filer ({num}GB)"),
                     _ => format!("Cleanup old log files ({num}GB)"),
                 }
             }
@@ -1584,6 +1790,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => format!("Räume alte Protokolle auf ({num}kB)"),
                     2 => format!("Régi naplófájlok tisztítása ({num}kB)"),
+                    3 => format!("Städa upp gamla logg-filer ({num}kB)"),
                     _ => format!("Cleanup old log files ({num}kB)"),
                 }
             }
@@ -1591,6 +1798,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => format!("Räume alte Protokolle auf ({num}MB)"),
                     2 => format!("Régi naplófájlok tisztítása ({num}MB)"),
+                    3 => format!("Städa upp gamla logg-filer ({num}MB)"),
                     _ => format!("Cleanup old log files ({num}MB)"),
                 }
             }
@@ -1599,6 +1807,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Lade verfügbare Protokolle...",
                 2 => "Elérhető naplófájlok betöltése...",
+                3 => "Laddar tillgängliga loggar...",
                 _ => "Loading available logs...",
             }
         }
@@ -1606,6 +1815,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Keine verfügbare Protokolle",
                 2 => "Nincs elérhető naplófájl",
+                3 => "Inga tillgängliga loggar",
                 _ => "No available logs",
             }
         }
@@ -1613,6 +1823,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Wähle Protokolle aus",
                 2 => "Válassz naplófájlt",
+                3 => "Välj log-fil",
                 _ => "Select log file",
             }
         }
@@ -1620,9 +1831,11 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Protokolle",
                 2 => "Naplók",
+                3 => "Loggar",
                 _ => "Logs",
             }
         }
+        #[rustfmt::skip]
         pub mod upload {
             pub fn get(key: &str) -> Option<&'static str> {
                 match key {
@@ -1636,6 +1849,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Fehler beim Hochladen von Protokollen",
                     2 => "Hiba a naplófájl feltöltésekor",
+                    3 => "Fel vid uppladdninga var loggar",
                     _ => "Error uploading log file",
                 }
             }
@@ -1643,6 +1857,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Hochladen",
                     2 => "Feltöltés",
+                    3 => "Ladda upp",
                     _ => "Upload",
                 }
             }
@@ -1650,6 +1865,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Lade Protokolle",
                     2 => "Naplófájl feltöltése",
+                    3 => "Ladda upp log-fil",
                     _ => "Uploading log file",
                 }
             }
@@ -1659,6 +1875,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Minecraft Version",
             2 => "Minecraft verzió",
+            3 => "Minecraft Version",
             _ => "Minecraft Version",
         }
     }
@@ -1666,6 +1883,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Arbeitsspeicher",
             2 => "Memória beállítása",
+            3 => "RAM-minne",
             _ => "Set Memory",
         }
     }
@@ -1673,6 +1891,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Modloader",
             2 => "Modloader",
+            3 => "Modloader",
             _ => "Modloader",
         }
     }
@@ -1680,6 +1899,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Name",
             2 => "Név",
+            3 => "Namn",
             _ => "Name",
         }
     }
@@ -1687,6 +1907,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "<Instanz Name>",
             2 => "<példány neve",
+            3 => "<instansens namn>",
             _ => "<instance name>",
         }
     }
@@ -1694,6 +1915,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Neue Instanz",
             2 => "Új példány",
+            3 => "Ny instans",
             _ => "New Instance",
         }
     }
@@ -1701,6 +1923,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Wähle eine Instanz aus",
             2 => "Válassz egy példányt",
+            3 => "Välj en instans",
             _ => "Select an instance",
         }
     }
@@ -1708,6 +1931,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Öffne .minecraft Ordner",
             2 => ".minecraft mappa megnyitása",
+            3 => "Öppna .minecraft mappen",
             _ => "Open .minecraft folder",
         }
     }
@@ -1715,6 +1939,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Verwende System OpenAL",
             2 => "Rendszer OpenAL használata",
+            3 => "Använd Systemets OpenAL (Ljud programvaru-bibliotek)",
             _ => "Use System OpenAL",
         }
     }
@@ -1722,6 +1947,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Spiel",
             2 => "Játék",
+            3 => "Spela",
             _ => "Play",
         }
     }
@@ -1729,6 +1955,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Schnellspiel",
             2 => "Gyorsjáték",
+            3 => "snabbspel",
             _ => "Quickplay",
         }
     }
@@ -1736,9 +1963,11 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Letze Instanzen",
             2 => "Legutóbbi példányok",
+            3 => "Senaste instanserna",
             _ => "Recent Instances",
         }
     }
+    #[rustfmt::skip]
     pub mod security {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {
@@ -1751,6 +1980,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Sicherheit",
                 2 => "Biztonság",
+                3 => "Säkerhet",
                 _ => "Security",
             }
         }
@@ -1758,6 +1988,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Isolierung",
                 2 => "Izolálás",
+                3 => "Sandlådeisolering",
                 _ => "Sandbox",
             }
         }
@@ -1766,6 +1997,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Wähle GLFW Bibiliothek aus",
             2 => "GLFW könyvtár kiválasztása",
+            3 => "Välj GLFW bibliotek",
             _ => "Select GLFW Library",
         }
     }
@@ -1773,6 +2005,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Bild auswählen",
             2 => "Válassz ikont",
+            3 => "Välj Ikon",
             _ => "Select Icon",
         }
     }
@@ -1780,6 +2013,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Wähle JVM Binary aus",
             2 => "JVM Binary választása",
+            3 => "Välj JVM programfil",
             _ => "Select JVM Binary",
         }
     }
@@ -1787,6 +2021,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Wähle OpenAL Bibiliothek aus",
             2 => "OpenAL könyvtár választása",
+            3 => "Välj OpenAL Bibliotek",
             _ => "Select OpenAL Library",
         }
     }
@@ -1794,6 +2029,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "PNG Bild auswählen",
             2 => "Válassz egy PNG ikont",
+            3 => "Välj PNG ikon",
             _ => "Select PNG Icon",
         }
     }
@@ -1801,6 +2037,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Server",
             2 => "Szerverek",
+            3 => "Servrar",
             _ => "Servers",
         }
     }
@@ -1808,9 +2045,11 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Vorabversionen anzeigen",
             2 => "Snapshot-ok mutatása",
+            3 => "Visa Snapshots",
             _ => "Show Snapshots",
         }
     }
+    #[rustfmt::skip]
     pub mod start {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {
@@ -1825,6 +2064,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Fehler beim Starten der Instanz",
                 2 => "Hiba a példány indításakor",
+                3 => "Ett fel uppstod då instansen startade",
                 _ => "Error starting instance",
             }
         }
@@ -1832,6 +2072,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Start",
                 2 => "Játék",
+                3 => "Starta",
                 _ => "Start",
             }
         }
@@ -1839,6 +2080,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Startet...",
                 2 => "Indítás...",
+                3 => "Startar...",
                 _ => "Launching...",
             }
         }
@@ -1846,6 +2088,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Stoppen...",
                 2 => "Leállítás...",
+                3 => "Stoppar...",
                 _ => "Stopping...",
             }
         }
@@ -1853,10 +2096,12 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => format!("Starte {name}"),
                 2 => format!("{name} indítása"),
+                3 => format!("Startar {name}"),
                 _ => format!("Launching {name}"),
             }
         }
     }
+    #[rustfmt::skip]
     pub mod sync {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {
@@ -1877,6 +2122,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => format!("{num} Instanzen enthalten einen „{name}“ Ordner. Bitte erstelle eine sicherheits Kopie und lösche den Ordner um zu synchronisieren"),
                 2 => format!("{num} példány már tartalmazza a(z) '{name}' mappát. Kérlek csinálj biztonsági mentést a mappákról, majd töröld őket, hogy bekapcsolhasd a szinkronizálást"),
+                3 => format!("{num} instans(er) innehåller redan en '{name}' mapp. Säkerhetskopiera och ta bort mapparna på ett säkert sätt för att aktivera synkronisering"),
                 _ => format!("{num} instance(s) already contain a '{name}' folder. Please safely backup and remove the folders to enable syncing"),
             }
         }
@@ -1884,6 +2130,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Benutzerdefiniert",
                 2 => "Egyedi",
+                3 => "Användardefinierat",
                 _ => "Custom",
             }
         }
@@ -1891,6 +2138,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Diese Optionen ermöglichen die Synchronisierung verschiedener Dateien/Ordner über verschiedene Instanzen hinweg",
                 2 => "Ezek az opciók megengedik a különböző fájlok/mappák szinkronizálását a példányok között",
+                3 => "Dessa alternativ möjliggör synkronisering av olika filer/mappar mellan instanser",
                 _ => "These options allow for syncing various files/folders across instances",
             }
         }
@@ -1898,6 +2146,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Deaktiviere Datensynchronisierung",
                 2 => "Példány fájlok szinkronizálásának kikapcsolása",
+                3 => "Stäng av instans fil synkning",
                 _ => "Disable Instance File Syncing",
             }
         }
@@ -1905,6 +2154,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Dateien",
                 2 => "Fájlok",
+                3 => "Filer",
                 _ => "Files",
             }
         }
@@ -1912,6 +2162,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Ordner",
                 2 => "Mappák",
+                3 => "Foldrar",
                 _ => "Folders",
             }
         }
@@ -1919,6 +2170,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => format!("({count}/{total} Ordner synchronisiert)"),
                 2 => format!("({count}/{total} mappa szinkronizálva)"),
+                3 => format!("({count}/{total} foldrar synkade)"),
                 _ => format!("({count}/{total} folders synced)"),
             }
         }
@@ -1926,6 +2178,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Synchronisierung",
                 2 => "Stinkronizál",
+                3 => "Synkar",
                 _ => "Syncing",
             }
         }
@@ -1933,6 +2186,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Mods",
                 2 => "Modok",
+                3 => "Mods",
                 _ => "Mods",
             }
         }
@@ -1940,6 +2194,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Öffne synchronisierte Ordner",
                 2 => "Szinkronizált mappák megnyitása",
+                3 => "Öppna katalogen för synkroniserade mappar",
                 _ => "Open synced folders directory",
             }
         }
@@ -1947,6 +2202,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Synchronisiere Datei",
                 2 => "Fájl szinkronizálása",
+                3 => "Synka fil",
                 _ => "Sync file",
             }
         }
@@ -1954,6 +2210,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Synchronisiere Ordner",
                 2 => "Mappa szinkronizálása",
+                3 => "Synka folder",
                 _ => "Sync folder",
             }
         }
@@ -1961,6 +2218,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => format!("Synchronisiere {name}"),
                 2 => format!("{name} fájl szinkronizálása"),
+                3 => format!("Synka {name} filen"),
                 _ => format!("Sync {name} file"),
             }
         }
@@ -1968,9 +2226,11 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => format!("Synchronisiere {name}"),
                 2 => format!("{name} mappa szinkronizálása"),
+                3 => format!("Synka {name} foldern"),
                 _ => format!("Sync {name} folder"),
             }
         }
+        #[rustfmt::skip]
         pub mod targets {
             pub fn get(key: &str) -> Option<&'static str> {
                 match key {
@@ -1997,6 +2257,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Synchronisiere Bobby Ordner (.bobby)",
                     2 => "Bobby (.bobby) mappájának szinkronizálása",
+                    3 => "Synka Bobby (.bobby) folder",
                     _ => "Sync Bobby (.bobby) folder",
                 }
             }
@@ -2004,6 +2265,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Synchronisiere command_history.txt",
                     2 => "command_history.txt szinkronizálása",
+                    3 => "Synka command_history.txt",
                     _ => "Sync command_history.txt",
                 }
             }
@@ -2011,6 +2273,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Synchronisiere Konfigurationsordner",
                     2 => "Konfigurációs mappa szinkronizálása",
+                    3 => "Synka konfig folder",
                     _ => "Sync config folder",
                 }
             }
@@ -2018,6 +2281,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Synchronisiere Distant Horizons (Distant_Horizons_server_data) Ordner",
                     2 => "Distant Horizons (Distant_Horizons_server_data) mappájának szinkronizálása",
+                    3 => "Synka Distant Horizons (Distant_Horizons_server_data) folder",
                     _ => "Sync Distant Horizons (Distant_Horizons_server_data) folder",
                 }
             }
@@ -2025,6 +2289,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Synchronisiere Flashback Ordner (flashback)",
                     2 => "Flashback (flashback) mappájának szinkronizálása",
+                    3 => "Synka Flashback (flashback) folder",
                     _ => "Sync Flashback (flashback) folder",
                 }
             }
@@ -2032,6 +2297,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Synchronisiere hotbar.nbt",
                     2 => "hotbar.nbt szinkronizálása",
+                    3 => "Synka hotbar.nbt",
                     _ => "Sync hotbar.nbt",
                 }
             }
@@ -2039,6 +2305,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Synchronisiere Journeymap Ordner (journeymap)",
                     2 => "Journeymap (journeymap) mappájának szinkronizálása",
+                    3 => "Synka Journeymap (journeymap) folder",
                     _ => "Sync Journeymap (journeymap) folder",
                 }
             }
@@ -2046,6 +2313,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Synchronisiere Litematic Ordner (schematic)",
                     2 => "Litematic (schematic) mappájának szinkronizálása",
+                    3 => "Synka Litematic (schematic) folder",
                     _ => "Sync Litematic (schematic) folder",
                 }
             }
@@ -2053,6 +2321,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Synchronisiere options.txt",
                     2 => "options.txt szinkronizálása",
+                    3 => "Synka options.txt",
                     _ => "Sync options.txt",
                 }
             }
@@ -2060,6 +2329,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Synchronisiere Ressourcenpakete",
                     2 => "Forráscsomagok mappájának szinkronizálása",
+                    3 => "Synka resurspakets folder",
                     _ => "Sync resourcepacks folder",
                 }
             }
@@ -2067,6 +2337,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Synchronisiere Welten Ordner",
                     2 => "Világok mappájának szinkronizálása",
+                    3 => "Synka värld-folder",
                     _ => "Sync saves folder",
                 }
             }
@@ -2074,6 +2345,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Synchronisiere Bildschirmaufnahmen",
                     2 => "Képernyőképek mappájának szinkronizálása",
+                    3 => "Synka skärmsklipps folder",
                     _ => "Sync screenshots folder",
                 }
             }
@@ -2081,6 +2353,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Synchronisiere servers.dat",
                     2 => "server.dat szinkronizálása",
+                    3 => "Synka server.dat",
                     _ => "Sync servers.dat",
                 }
             }
@@ -2088,6 +2361,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Synchronisiere Shaderpakete",
                     2 => "Shadercsomagok mappájának szinkronizálása",
+                    3 => "Synka shaderpakets folder",
                     _ => "Sync shaderpacks folder",
                 }
             }
@@ -2095,6 +2369,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Synchronisiere Voxy Ordner (.voxy)",
                     2 => "Voxy (.voxy) mappájának szinkronizálása",
+                    3 => "Synka Voxy (.voxy) folder",
                     _ => "Sync Voxy (.voxy) folder",
                 }
             }
@@ -2102,6 +2377,7 @@ pub mod instance {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => "Synchronisiere Xaero's Minimap Ordner (xaero)",
                     2 => "Xaero's Minimap (xaero) mappájának szinkronizálása",
+                    3 => "Synka Xaero's Minimap (xaero) folder",
                     _ => "Sync Xaero's Minimap (xaero) folder",
                 }
             }
@@ -2110,6 +2386,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => format!("{count}/{total} Instanzen konnten nicht synchronisiert werden!"),
                 2 => format!("{count}/{total} példány nem szinkronizálható!"),
+                3 => format!("{count}/{total} instanser kan ej synkas!"),
                 _ => format!("{count}/{total} instances are unable to be synced!"),
             }
         }
@@ -2118,6 +2395,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Instanzen",
             2 => "Példányok",
+            3 => "Instanser",
             _ => "Instances",
         }
     }
@@ -2125,6 +2403,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Insgesammte Spielzeit",
             2 => "Össz játékidő",
+            3 => "Total speltid",
             _ => "Total Playtime",
         }
     }
@@ -2132,6 +2411,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Instanz konnte nicht gefunden werden",
             2 => "Példány nem található",
+            3 => "Kunde ej hitta instans",
             _ => "Unable to find instance",
         }
     }
@@ -2139,6 +2419,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Unbekannte Instanz",
             2 => "Névtelen példány",
+            3 => "namlös instans",
             _ => "Unnamed Instance",
         }
     }
@@ -2146,6 +2427,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Vanilla",
             2 => "Vanilla",
+            3 => "Vanilla",
             _ => "Vanilla",
         }
     }
@@ -2153,9 +2435,11 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Version",
             2 => "Verzió",
+            3 => "Version",
             _ => "Version",
         }
     }
+    #[rustfmt::skip]
     pub mod versions_loading {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {
@@ -2170,6 +2454,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Fehler beim laden von Minecraft Versionen",
                 2 => "Hiba a Minecraft verziók betöltésekor",
+                3 => "Ett vid laddning av Minecraft versioner",
                 _ => "Error loading Minecraft versions",
             }
         }
@@ -2177,6 +2462,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Lade Minecraft Versionen...",
                 2 => "Minecraft verziók betöltése...",
+                3 => "Laddar Minecraft Versioner...",
                 _ => "Loading Minecraft Versions...",
             }
         }
@@ -2184,6 +2470,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Fehler beim Laden möglicher Modloader-Versionen",
                 2 => "Hiba történt a lehetséges verziók betöltésekor",
+                3 => "Ett fel uppstod då möjliga versioner skulle laddas in",
                 _ => "Error loading possible loader versions",
             }
         }
@@ -2191,6 +2478,7 @@ pub mod instance {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Versionen neuladen",
                 2 => "Verziók újratöltése",
+                3 => "Ladda om Versioner",
                 _ => "Reload Versions",
             }
         }
@@ -2199,6 +2487,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Ansehen",
             2 => "Nézet",
+            3 => "Visa",
             _ => "View",
         }
     }
@@ -2206,6 +2495,7 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Welten",
             2 => "Világok",
+            3 => "Världar",
             _ => "Worlds",
         }
     }
@@ -2213,10 +2503,12 @@ pub mod instance {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Füge Wrapper Befehl hinzu",
             2 => "Wrapper parancs hozzáadása",
+            3 => "Lägg till ett wrapper-kommand",
             _ => "Add Wrapper Command",
         }
     }
 }
+#[rustfmt::skip]
 pub mod login {
     pub fn get(key: &str) -> Option<&'static str> {
         match key {
@@ -2229,6 +2521,7 @@ pub mod login {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Fehler beim einloggen",
             2 => "Hiba történt bejelentkezés közben",
+            3 => "Fel vid inloggningen",
             _ => "Error while logging in",
         }
     }
@@ -2236,10 +2529,12 @@ pub mod login {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Einloggen",
             2 => "Bejelentkezés",
+            3 => "Logga in",
             _ => "Login",
         }
     }
 }
+#[rustfmt::skip]
 pub mod modrinth {
     pub fn get(key: &str) -> Option<&'static str> {
         match key {
@@ -2247,6 +2542,7 @@ pub mod modrinth {
             _ => None,
         }
     }
+    #[rustfmt::skip]
     pub mod category {
         pub fn get(key: &str, short: bool) -> Option<&'static str> {
             match key {
@@ -2350,6 +2646,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "128x",
                 2 => "128x",
+                3 => "128x",
                 _ => "128x",
             }
         }
@@ -2357,6 +2654,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "16x",
                 2 => "16x",
+                3 => "16x",
                 _ => "16x",
             }
         }
@@ -2364,6 +2662,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "256x",
                 2 => "256x",
+                3 => "256x",
                 _ => "256x",
             }
         }
@@ -2371,6 +2670,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "32x",
                 2 => "32x",
+                3 => "32x",
                 _ => "32x",
             }
         }
@@ -2378,6 +2678,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "48x",
                 2 => "48x",
+                3 => "48x",
                 _ => "48x",
             }
         }
@@ -2385,6 +2686,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "512x oder höher",
                 2 => "512x vagy nagyobb",
+                3 => "512x eller högre",
                 _ => "512x or higher",
             }
         }
@@ -2392,6 +2694,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "64x",
                 2 => "64x",
+                3 => "64x",
                 _ => "64x",
             }
         }
@@ -2399,6 +2702,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "8x oder weniger",
                 2 => "8x vagy kisebb",
+                3 => "8x eller lägre",
                 _ => "8x or lower",
             }
         }
@@ -2406,6 +2710,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Abenteuer",
                 2 => "Kaland",
+                3 => "Äventyr",
                 _ => "Adventure",
             }
         }
@@ -2413,6 +2718,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Atmosphere",
                 2 => "Atmoszféra",
+                3 => "atmosfär",
                 _ => "Atmosphere",
             }
         }
@@ -2420,6 +2726,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Audio",
                 2 => "Hang",
+                3 => "Ljud",
                 _ => "Audio",
             }
         }
@@ -2427,6 +2734,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Babric",
                 2 => "Babric",
+                3 => "Babric",
                 _ => "Babric",
             }
         }
@@ -2434,6 +2742,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Blöcke",
                 2 => "Blokkok",
+                3 => "Blocks",
                 _ => "Blocks",
             }
         }
@@ -2441,6 +2750,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Bloom",
                 2 => "Bloom",
+                3 => "Bloom",
                 _ => "Bloom",
             }
         }
@@ -2448,6 +2758,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "BTA (Babric)",
                 2 => "BTA (Babric)",
+                3 => "BTA (Babric)",
                 _ => "BTA (Babric)",
             }
         }
@@ -2455,6 +2766,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Bukkit",
                 2 => "Bukkit",
+                3 => "Bukkit",
                 _ => "Bukkit",
             }
         }
@@ -2462,6 +2774,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "BungeeCord",
                 2 => "BungeeCord",
+                3 => "BungeeCord",
                 _ => "BungeeCord",
             }
         }
@@ -2469,6 +2782,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Canvas",
                 2 => "Canvas",
+                3 => "Canvas",
                 _ => "Canvas",
             }
         }
@@ -2476,6 +2790,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Cartoon",
                 2 => "Rajzfilmes",
+                3 => "Teknad",
                 _ => "Cartoon",
             }
         }
@@ -2483,6 +2798,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Herausforderend",
                 2 => "Kihívó",
+                3 => "Utmaning",
                 _ => "Challenging",
             }
         }
@@ -2490,6 +2806,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Farbige Lichter",
                 2 => "Színes világítás",
+                3 => "Färgat Ljus",
                 _ => "Colored Lighting",
             }
         }
@@ -2497,6 +2814,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Kampf",
                 2 => "Harc",
+                3 => "Strid",
                 _ => "Combat",
             }
         }
@@ -2504,6 +2822,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Core-Shaders",
                 2 => "Alap shaderek",
+                3 => "Core-shaders",
                 _ => "Core Shaders",
             }
         }
@@ -2511,6 +2830,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Seltsam",
                 2 => "Átkozott",
+                3 => "Förbannad",
                 _ => "Cursed",
             }
         }
@@ -2518,6 +2838,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Data Pack",
                 2 => "Adatcsomag",
+                3 => "Data Pack",
                 _ => "Data Pack",
             }
         }
@@ -2525,6 +2846,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Dekoration",
                 2 => "Dekoráció",
+                3 => "Dekoration",
                 _ => "Decoration",
             }
         }
@@ -2532,6 +2854,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Wirtschaft",
                 2 => "Gazdaság",
+                3 => "Ekonomi",
                 _ => "Economy",
             }
         }
@@ -2539,6 +2862,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Entitäten",
                 2 => "Entitások",
+                3 => "Entiteter",
                 _ => "Entities",
             }
         }
@@ -2546,6 +2870,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Umgebung",
                 2 => "Környezet",
+                3 => "Miljö",
                 _ => "Environment",
             }
         }
@@ -2553,6 +2878,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Ausrüstung",
                 2 => "Felszerelés",
+                3 => "Utrustning",
                 _ => "Equipment",
             }
         }
@@ -2560,6 +2886,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Fabric",
                 2 => "Fabric",
+                3 => "Fabric",
                 _ => "Fabric",
             }
         }
@@ -2567,6 +2894,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Fantasie",
                 2 => "Fantázia",
+                3 => "Fantasi",
                 _ => "Fantasy",
             }
         }
@@ -2574,6 +2902,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Folia",
                 2 => "Folia",
+                3 => "Folia",
                 _ => "Folia",
             }
         }
@@ -2581,6 +2910,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Vegetation",
                 2 => "Növényzet",
+                3 => "Vegetation",
                 _ => "Foliage",
             }
         }
@@ -2588,6 +2918,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Schriftarten",
                 2 => "Betűtípusok",
+                3 => "Fonter",
                 _ => "Fonts",
             }
         }
@@ -2595,6 +2926,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Essen",
                 2 => "Étel",
+                3 => "Mat",
                 _ => "Food",
             }
         }
@@ -2602,6 +2934,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Forge",
                 2 => "Forge",
+                3 => "Forge",
                 _ => "Forge",
             }
         }
@@ -2609,6 +2942,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Spielmechaniken",
                 2 => "Játék mechanikák",
+                3 => "Spelmekaniker",
                 _ => "Game Mechanics",
             }
         }
@@ -2616,6 +2950,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Geyser",
                 2 => "Geyser",
+                3 => "Geyser",
                 _ => "Geyser",
             }
         }
@@ -2623,6 +2958,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "GUI",
                 2 => "GUI",
+                3 => "GUI",
                 _ => "GUI",
             }
         }
@@ -2630,6 +2966,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Hoch",
                 2 => "Magas",
+                3 => "Högt",
                 _ => "High",
             }
         }
@@ -2637,6 +2974,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Iris",
                 2 => "Iris",
+                3 => "Iris",
                 _ => "Iris",
             }
         }
@@ -2644,6 +2982,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Gegenstände",
                 2 => "Tárgyak",
+                3 => "Items",
                 _ => "Items",
             }
         }
@@ -2651,6 +2990,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Java Agent",
                 2 => "Java Agent",
+                3 => "Java Agent",
                 _ => "Java Agent",
             }
         }
@@ -2658,6 +2998,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Etwas von allem",
                 2 => "Mindenből egy kicsi",
+                3 => "Allt möjligt",
                 _ => "Kitchen sink",
             }
         }
@@ -2665,6 +3006,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Legacy Fabric",
                 2 => "Legacy Fabric",
+                3 => "Legacy Fabric",
                 _ => "Legacy Fabric",
             }
         }
@@ -2672,6 +3014,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Bibiliothek",
                 2 => "Könyvtár",
+                3 => "Bibliotek",
                 _ => "Library",
             }
         }
@@ -2679,6 +3022,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Leichtgewichtig",
                 2 => "Könnyű",
+                3 => "Lätt",
                 _ => "Lightweight",
             }
         }
@@ -2686,6 +3030,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "LiteLoader",
                 2 => "LiteLoader",
+                3 => "LiteLoader",
                 _ => "LiteLoader",
             }
         }
@@ -2693,6 +3038,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Lokalisierung",
                 2 => "Nyelv",
+                3 => "Lokalisering",
                 _ => "Locale",
             }
         }
@@ -2700,6 +3046,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Niedrig",
                 2 => "Alacsony",
+                3 => "Låg",
                 _ => "Low",
             }
         }
@@ -2707,6 +3054,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Magie",
                 2 => "Mágia",
+                3 => "Magi",
                 _ => "Magic",
             }
         }
@@ -2714,6 +3062,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Verwaltung",
                 2 => "Kezelés",
+                3 => "Förvaltning",
                 _ => "Management",
             }
         }
@@ -2721,6 +3070,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Mittel",
                 2 => "Közepes",
+                3 => "Medium",
                 _ => "Medium",
             }
         }
@@ -2728,6 +3078,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Minispiel",
                 2 => "Minijáték",
+                3 => "Minispel",
                 _ => "Minigame",
             }
         }
@@ -2735,6 +3086,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Mobs",
                 2 => "Mobok",
+                3 => "Mobs",
                 _ => "Mobs",
             }
         }
@@ -2742,6 +3094,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Modifiziert",
                 2 => "Modolt",
+                3 => "Moddat",
                 _ => "Modded",
             }
         }
@@ -2749,6 +3102,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Modelle",
                 2 => "Modellek",
+                3 => "Modeller",
                 _ => "Models",
             }
         }
@@ -2756,6 +3110,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Risugami's ModLoader",
                 2 => "Risumagi's ModLoader",
+                3 => "Risumagi's ModLoader",
                 _ => "Risugami's ModLoader",
             }
         }
@@ -2763,6 +3118,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Mehrspieler",
                 2 => "Többjátékos",
+                3 => "Flerspelare",
                 _ => "Multiplayer",
             }
         }
@@ -2770,6 +3126,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "NeoForge",
                 2 => "NeoForge",
+                3 => "NeoForge",
                 _ => "NeoForge",
             }
         }
@@ -2777,6 +3134,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "NilLoader",
                 2 => "NilLoader",
+                3 => "NilLoader",
                 _ => "NilLoader",
             }
         }
@@ -2784,6 +3142,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "OptiFine",
                 2 => "OptiFine",
+                3 => "OptiFine",
                 _ => "OptiFine",
             }
         }
@@ -2791,6 +3150,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Optimierung",
                 2 => "Optimalizálás",
+                3 => "Optimisation",
                 _ => "Optimization",
             }
         }
@@ -2798,6 +3158,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Ornithe",
                 2 => "Ornithe",
+                3 => "Ornithe",
                 _ => "Ornithe",
             }
         }
@@ -2805,6 +3166,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Paper",
                 2 => "Paper",
+                3 => "Paper",
                 _ => "Paper",
             }
         }
@@ -2819,6 +3181,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "PBR",
                 2 => "PBR",
+                3 => "PBR",
                 _ => "PBR",
             }
         }
@@ -2826,6 +3189,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Kartoffel",
                 2 => "Krumpli",
+                3 => "Potatis",
                 _ => "Potato",
             }
         }
@@ -2833,6 +3197,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Purpur",
                 2 => "Purpur",
+                3 => "Purpur",
                 _ => "Purpur",
             }
         }
@@ -2840,6 +3205,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Aufgaben",
                 2 => "Küldetések",
+                3 => "Uppdrag",
                 _ => "Quests",
             }
         }
@@ -2847,6 +3213,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Quilt",
                 2 => "Quilt",
+                3 => "Quilt",
                 _ => "Quilt",
             }
         }
@@ -2854,6 +3221,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Realistisch",
                 2 => "Realisztikus",
+                3 => "realistiskt",
                 _ => "Realistic",
             }
         }
@@ -2861,6 +3229,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Reflektionen",
                 2 => "Tükröződések",
+                3 => "Reflektioner",
                 _ => "Reflections",
             }
         }
@@ -2868,6 +3237,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Rift",
                 2 => "Rift",
+                3 => "Rift",
                 _ => "Rift",
             }
         }
@@ -2875,6 +3245,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Screenshot",
                 2 => "Képernyőkép",
+                3 => "Skärmklipp",
                 _ => "Screenshot",
             }
         }
@@ -2882,6 +3253,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Semi-Realistisch",
                 2 => "Félig valósághű",
+                3 => "Semi realistiskt",
                 _ => "Semi-realistic",
             }
         }
@@ -2889,6 +3261,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Schatten",
                 2 => "Árnyékok",
+                3 => "Skuggor",
                 _ => "Shadows",
             }
         }
@@ -2896,6 +3269,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Einfach",
                 2 => "Egyszerű",
+                3 => "Simplistiskt",
                 _ => "Simplistic",
             }
         }
@@ -2903,6 +3277,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Sozial",
                 2 => "Szociális",
+                3 => "Social",
                 _ => "Social",
             }
         }
@@ -2910,6 +3285,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Spigot",
                 2 => "Spigot",
+                3 => "Spigot",
                 _ => "Spigot",
             }
         }
@@ -2917,6 +3293,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Sponge",
                 2 => "Sponge",
+                3 => "Sponge",
                 _ => "Sponge",
             }
         }
@@ -2924,6 +3301,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Lagerung",
                 2 => "Tárhely",
+                3 => "Utrustning",
                 _ => "Storage",
             }
         }
@@ -2931,6 +3309,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Technologie",
                 2 => "Technológia",
+                3 => "Teknologi",
                 _ => "Technology",
             }
         }
@@ -2938,6 +3317,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Thematisch",
                 2 => "Tematikus",
+                3 => "Temat",
                 _ => "Themed",
             }
         }
@@ -2945,6 +3325,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Transportation",
                 2 => "Szállítás",
+                3 => "Transportation",
                 _ => "Transportation",
             }
         }
@@ -2952,6 +3333,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Optimierungen",
                 2 => "Finomítások",
+                3 => "Justeringar",
                 _ => "Tweaks",
             }
         }
@@ -2959,6 +3341,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Nützlich",
                 2 => "Hasznos",
+                3 => "Vertyg",
                 _ => "Utility",
             }
         }
@@ -2966,6 +3349,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Vanilla Shader",
                 2 => "Vanilla Shader",
+                3 => "Vanilla Shader",
                 _ => "Vanilla Shader",
             }
         }
@@ -2973,6 +3357,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Vanilla-Ähnlich",
                 2 => "Vanilla-szerű",
+                3 => "Vanilla liknande",
                 _ => "Vanilla-like",
             }
         }
@@ -2980,6 +3365,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Velocity",
                 2 => "Velocity",
+                3 => "Velocity",
                 _ => "Velocity",
             }
         }
@@ -2987,6 +3373,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Waterfall",
                 2 => "Waterfall",
+                3 => "Waterfall",
                 _ => "Waterfall",
             }
         }
@@ -2994,10 +3381,12 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => if short { "Weltgenerierung" } else { "Weltgenerierung" },
                 2 => if short { "Generálás" } else { "Világgenerálás" },
+                3 => if short { "Generering" } else { "Världsgeneration" },
                 _ => if short { "Worldgen" } else { "World Generation" },
             }
         }
     }
+    #[rustfmt::skip]
     pub mod environment {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {
@@ -3014,14 +3403,16 @@ pub mod modrinth {
         pub fn client_and_server() -> &'static str {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Client und Server",
-                2 => "Kliens és szerver",
-                _ => "Client and server",
+                2 => "Kliens és Szerver",
+                3 => "Klient och Server",
+                _ => "Client and Server",
             }
         }
         pub fn client_only() -> &'static str {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Nur Client",
                 2 => "Csak kliens",
+                3 => "Endast Klient",
                 _ => "Client only",
             }
         }
@@ -3029,6 +3420,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Client (Server Optional)",
                 2 => "Kliens (Szerver opcionális)",
+                3 => "Klient (falfri Server)",
                 _ => "Client (server optional)",
             }
         }
@@ -3036,6 +3428,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Client oder Server",
                 2 => "Kliens vagy szerver",
+                3 => "Klient och Server",
                 _ => "Client or server",
             }
         }
@@ -3043,6 +3436,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Nur Server",
                 2 => "Csak szerver",
+                3 => "Endast Server",
                 _ => "Server only",
             }
         }
@@ -3050,6 +3444,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Server (Client Optional)",
                 2 => "Szerver (kliens opcionális)",
+                3 => "Server (falfri Klient)",
                 _ => "Server (client optional)",
             }
         }
@@ -3057,6 +3452,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Unbekannte Umgebung",
                 2 => "Ismeretlen környezet",
+                3 => "Okänd miljö",
                 _ => "Unknown environment",
             }
         }
@@ -3065,9 +3461,11 @@ pub mod modrinth {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Modrinth",
             2 => "Modrinth",
+            3 => "Modrinth",
             _ => "Modrinth",
         }
     }
+    #[rustfmt::skip]
     pub mod sort {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {
@@ -3083,6 +3481,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Downloads",
                 2 => "Letöltések",
+                3 => "Nedladdningar",
                 _ => "Downloads",
             }
         }
@@ -3090,6 +3489,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Follower",
                 2 => "Követők",
+                3 => "Följare",
                 _ => "Follows",
             }
         }
@@ -3097,6 +3497,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Neuste",
                 2 => "Legújabb",
+                3 => "Nyast",
                 _ => "Newest",
             }
         }
@@ -3104,6 +3505,7 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Relevanz",
                 2 => "Relevancia",
+                3 => "Relevans",
                 _ => "Relevance",
             }
         }
@@ -3111,15 +3513,18 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Aktualisiert",
                 2 => "Frissítve",
+                3 => "Uppdaterat",
                 _ => "Updated",
             }
         }
     }
+    #[rustfmt::skip]
     pub mod versions {
         pub fn alpha(name: &str) -> String {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => format!("{name} (Alpha)"),
                 2 => format!("{name} (Alpha)"),
+                3 => format!("{name} (Alpha)"),
                 _ => format!("{name} (Alpha)"),
             }
         }
@@ -3127,11 +3532,13 @@ pub mod modrinth {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => format!("{name} (Beta)"),
                 2 => format!("{name} (Beta)"),
+                3 => format!("{name} (Beta)"),
                 _ => format!("{name} (Beta)"),
             }
         }
     }
 }
+#[rustfmt::skip]
 pub mod settings {
     pub fn get(key: &str) -> Option<&'static str> {
         match key {
@@ -3141,6 +3548,7 @@ pub mod settings {
             _ => None,
         }
     }
+    #[rustfmt::skip]
     pub mod delete {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {
@@ -3154,6 +3562,7 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Shift+Klick um Instanz-Löschungsbestätigung zu überspringen",
                 2 => "Shift+Katt a példány törlésének megerősítésének az átlépéséhez",
+                3 => "Shift-klicka för att skippa instans raderingskonfirmation",
                 _ => "Shift+Click to skip instance delete confirmation",
             }
         }
@@ -3161,6 +3570,7 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Shift+Klick um Mod-Löschungsbestätigung zu überspringen",
                 2 => "Shift+Katt a mod törlésének megerősítésének az átlépéséhez",
+                3 => "Shift-klicka för att skippa mod raderingskonfirmation",
                 _ => "Shift+Click to skip mod delete confirmation",
             }
         }
@@ -3168,6 +3578,7 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Löschung",
                 2 => "Törlés",
+                3 => "Radering",
                 _ => "Deletion",
             }
         }
@@ -3176,6 +3587,7 @@ pub mod settings {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Benutzeroberfläche",
             2 => "Felület",
+            3 => "Gränsnitt",
             _ => "Interface",
         }
     }
@@ -3183,9 +3595,11 @@ pub mod settings {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Netzwerk",
             2 => "Hálózat",
+            3 => "Nätvärk",
             _ => "Network",
         }
     }
+    #[rustfmt::skip]
     pub mod privacy {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {
@@ -3200,6 +3614,7 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Verstecke Server Adresse",
                 2 => "Szerverek címének elrejtése",
+                3 => "Göm server addresser",
                 _ => "Hide server addresses",
             }
         }
@@ -3207,6 +3622,7 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Verstecke Skins",
                 2 => "Kinézetek elrejtése",
+                3 => "Göm skinn",
                 _ => "Hide skins",
             }
         }
@@ -3214,6 +3630,7 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Verstecke Nutzernamen",
                 2 => "Felhasználónevek elrejtése",
+                3 => "Göm användarnamn",
                 _ => "Hide usernames",
             }
         }
@@ -3221,10 +3638,12 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Privatsphäre",
                 2 => "Adatvédelem",
+                3 => "Integritet",
                 _ => "Privacy",
             }
         }
     }
+    #[rustfmt::skip]
     pub mod proxy {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {
@@ -3245,6 +3664,7 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Authentifizierung",
                 2 => "Hitelesítés",
+                3 => "Autentisering",
                 _ => "Authentication",
             }
         }
@@ -3252,6 +3672,7 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Aktiviere Proxy",
                 2 => "Proxy engedélyezése",
+                3 => "Aktivira Proxy",
                 _ => "Enable Proxy",
             }
         }
@@ -3259,6 +3680,7 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Host",
                 2 => "Kiszolgáló",
+                3 => "Host",
                 _ => "Host",
             }
         }
@@ -3266,6 +3688,7 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Achtung - Proxyeinstellungen sind nur für Pandora, nicht für Minecraft",
                 2 => "Megjegyzés - A proxy beállítások csak az indítóra hatnak, nem a játékra",
+                3 => "Observera - Proxy inställningar gäller endast för launchern inte för själva spelet",
                 _ => "Note - Proxy settings only apply to the launcher, not the game itself",
             }
         }
@@ -3273,6 +3696,7 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Passwort",
                 2 => "Jelszó",
+                3 => "Lösenord",
                 _ => "Password",
             }
         }
@@ -3280,6 +3704,7 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Port",
                 2 => "Port",
+                3 => "Port",
                 _ => "Port",
             }
         }
@@ -3287,6 +3712,7 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Protokoll",
                 2 => "Protokoll",
+                3 => "Protokoll",
                 _ => "Protocol",
             }
         }
@@ -3294,6 +3720,7 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Proxy Einstellung",
                 2 => "Proxy beállítások",
+                3 => "Proxy inställningar",
                 _ => "Proxy Settings",
             }
         }
@@ -3301,6 +3728,7 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Nutze Authentifizierung",
                 2 => "Hitelesítés használata",
+                3 => "Använd autentisering",
                 _ => "Use Authentication",
             }
         }
@@ -3308,10 +3736,12 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Nutzername",
                 2 => "Felhasználónév",
+                3 => "Användarnamn",
                 _ => "Username",
             }
         }
     }
+    #[rustfmt::skip]
     pub mod theme {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {
@@ -3325,6 +3755,7 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Öffne Farbschema Ordner",
                 2 => "Téma mappa megnyitása",
+                3 => "Öppna tema folder",
                 _ => "Open theme folder",
             }
         }
@@ -3332,6 +3763,7 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Öffne Farbschema Repository",
                 2 => "Téma repository megnyitása",
+                3 => "Öppna tema git-repo",
                 _ => "Open theme repository",
             }
         }
@@ -3339,6 +3771,7 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Farbschema",
                 2 => "Téma",
+                3 => "Tema",
                 _ => "Theme",
             }
         }
@@ -3347,9 +3780,11 @@ pub mod settings {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Einstellungen",
             2 => "Beállítások",
+            3 => "Inställningar",
             _ => "Settings",
         }
     }
+    #[rustfmt::skip]
     pub mod windows {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {
@@ -3365,6 +3800,7 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Schließe alle anderen Fenster when das Hauptfenster geschlossen ist",
                 2 => "Minden másik ablak bezárása a fő ablak bezárásakor",
+                3 => "Stäng alla andra fönster när huvudfönstret stängs",
                 _ => "Close all other windows when main window closed",
             }
         }
@@ -3372,6 +3808,7 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Verstecke Hauptfenster beim Start",
                 2 => "Fő ablak elrejtése a játék indításakor",
+                3 => "Göm huvudfönstret vid spelstart",
                 _ => "Hide main window on launch",
             }
         }
@@ -3379,6 +3816,7 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Öffne Spiel Ausgabe beim Start",
                 2 => "Játéknapló megnyitása a játék indításakor",
+                3 => "Öppna spelutdata vid spelstart",
                 _ => "Open game output on launch",
             }
         }
@@ -3386,16 +3824,19 @@ pub mod settings {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Fenster",
                 2 => "Ablakok",
+                3 => "Fönster",
                 _ => "Windows",
             }
         }
         pub fn use_os_titlebar() -> &'static str {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
+                3 => "Använd operativsystemets titlebar (kräver omstart)",
                 _ => "Use OS titlebar (requires restart)",
             }
         }
     }
 }
+#[rustfmt::skip]
 pub mod skins {
     pub fn get(key: &str) -> Option<&'static str> {
         match key {
@@ -3416,6 +3857,7 @@ pub mod skins {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Füge von Datei hinzu",
             2 => "Hozzáadás fájlból",
+            3 => "Lägg till från fil",
             _ => "Add from file",
         }
     }
@@ -3430,6 +3872,7 @@ pub mod skins {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Umhänge",
             2 => "Köpenyek",
+            3 => "Mantlar",
             _ => "Capes",
         }
     }
@@ -3437,6 +3880,7 @@ pub mod skins {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Kopiern",
             2 => "Másolás",
+            3 => "Kopiera",
             _ => "Copy",
         }
     }
@@ -3444,6 +3888,7 @@ pub mod skins {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Von Spieler kopieren",
             2 => "Másolás egy játékosról",
+            3 => "Kopiera från spelare",
             _ => "Copy from player",
         }
     }
@@ -3451,6 +3896,7 @@ pub mod skins {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Herunterladen",
             2 => "Letöltés",
+            3 => "Ladda-ned",
             _ => "Download",
         }
     }
@@ -3458,6 +3904,7 @@ pub mod skins {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => format!("Lade {username}s Skin..."),
             2 => format!("{username} kinézeteinek betöltése..."),
+            3 => format!("Laddar {username}s skinn..."),
             _ => format!("Loading {username}'s skin..."),
         }
     }
@@ -3465,6 +3912,7 @@ pub mod skins {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => format!("Einloggen um {username}s Skin anzusehen/bearbeiten"),
             2 => format!("Jelentkezz be, hogy megnézd/szerkeszd {username} kinézeteit"),
+            3 => format!("Logga-in för att visa/redigera {username}s skin"),
             _ => format!("Login to view/edit {username}'s skin"),
         }
     }
@@ -3472,6 +3920,7 @@ pub mod skins {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Skins können nicht auf Offline Konte angewant werden",
             2 => "Nem alkalmazhatóak kinézetek offline fiókokra",
+            3 => "Skins kan inte tillämpas på offline-konton",
             _ => "Skins cannot be applied to offline accounts",
         }
     }
@@ -3479,6 +3928,7 @@ pub mod skins {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Öffne Ordner",
             2 => "Mappa megnyitása",
+            3 => "Öppna folder",
             _ => "Open folder",
         }
     }
@@ -3486,9 +3936,11 @@ pub mod skins {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Wähle ein Skin aus",
             2 => "Válassz egy kinézetet",
+            3 => "Välj ett skinn",
             _ => "Select Skin",
         }
     }
+    #[rustfmt::skip]
     pub mod switch_view {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {
@@ -3501,6 +3953,7 @@ pub mod skins {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Wechsle zu Model",
                 2 => "Váltás a modellre",
+                3 => "Byt till model",
                 _ => "Switch to model",
             }
         }
@@ -3508,6 +3961,7 @@ pub mod skins {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Wechle zu Textur",
                 2 => "Váltás a textúrára",
+                3 => "Byt till textur",
                 _ => "Switch to texture",
             }
         }
@@ -3516,6 +3970,7 @@ pub mod skins {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Skins",
             2 => "Kinézetek",
+            3 => "Skinn",
             _ => "Skins",
         }
     }
@@ -3523,10 +3978,12 @@ pub mod skins {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => format!("Konnte {username}s Skin nicht laden"),
             2 => format!("Nem sikerült betölteni {username} kinézeteit"),
+            3 => format!("Kunde ej ladda {username}s skinn"),
             _ => format!("Unable to load {username}'s skin"),
         }
     }
 }
+#[rustfmt::skip]
 pub mod system {
     pub fn get(key: &str) -> Option<&'static str> {
         match key {
@@ -3540,6 +3997,7 @@ pub mod system {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Das Backend ist unerwartet abgestürzt",
             2 => "A háttérfolyamat váratlanul leállt",
+            3 => "Backgrundsprocessen stoppades oväntat",
             _ => "Backend has abruptly shutdown",
         }
     }
@@ -3547,6 +4005,7 @@ pub mod system {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Minecraft Log Ausgabe",
             2 => "Minecraft játéknapló",
+            3 => "Minecraft Log utmatning",
             _ => "Minecraft Game Output",
         }
     }
@@ -3554,9 +4013,11 @@ pub mod system {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Falscher Metadaten Type! Pandora Fehler!",
             2 => "Hibás metaadat típus! Pandora hiba!",
+            3 => "Fel medatata typ! En bug hos oss (Pandora)",
             _ => "Wrong metadata type! Pandora bug!",
         }
     }
+    #[rustfmt::skip]
     pub mod update {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {
@@ -3570,6 +4031,7 @@ pub mod system {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => format!("Aktuelle Version: {ver}"),
                 2 => format!("Jelenlegi verzió: {ver}"),
+                3 => format!("Nuvarande version: {ver}"),
                 _ => format!("Current version: {ver}"),
             }
         }
@@ -3577,6 +4039,7 @@ pub mod system {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Aktualisierung konnte nicht installiert werden",
                 2 => "Nem sikerült a frissítés telepítése",
+                3 => "Kunde ej installera uppdateringen",
                 _ => "Unable to install update",
             }
         }
@@ -3584,6 +4047,7 @@ pub mod system {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Später",
                 2 => "Később",
+                3 => "Senare",
                 _ => "Later",
             }
         }
@@ -3591,14 +4055,17 @@ pub mod system {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => format!("Neue Version: {ver}"),
                 2 => format!("Új verzió: {ver}"),
+                3 => format!("Ny version: {ver}"),
                 _ => format!("New version: {ver}"),
             }
         }
+        #[rustfmt::skip]
         pub mod size {
             pub fn bytes(num: usize) -> String {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => format!("Größe der Aktualisierung: {num} bytes"),
                     2 => format!("Frissítés mérete: {num} byte"),
+                    3 => format!("Updateringsstorlek: {num} byte"),
                     _ => format!("Update size: {num} bytes"),
                 }
             }
@@ -3606,6 +4073,7 @@ pub mod system {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => format!("Größe der Aktualisierung: {num}GB"),
                     2 => format!("Frissítés mérete: {num}GB"),
+                    3 => format!("Updateringsstorlek: {num}GB"),
                     _ => format!("Update size: {num}GB"),
                 }
             }
@@ -3613,6 +4081,7 @@ pub mod system {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => format!("Größe der Aktualisierung: {num}kB"),
                     2 => format!("Frissítés mérete: {num}kB"),
+                    3 => format!("Updateringsstorlek: {num}kB"),
                     _ => format!("Update size: {num}kB"),
                 }
             }
@@ -3620,6 +4089,7 @@ pub mod system {
                 match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                     1 => format!("Größe der Aktualisierung: {num}MB"),
                     2 => format!("Frissítés mérete: {num}MB"),
+                    3 => format!("Updateringsstorlek: {num}MB"),
                     _ => format!("Update size: {num}MB"),
                 }
             }
@@ -3628,6 +4098,7 @@ pub mod system {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
                 1 => "Pandora aktualisieren?",
                 2 => "Frissíted a Pandorát?",
+                3 => "Uppdatera Pandora?",
                 _ => "Update Pandora?",
             }
         }


### PR DESCRIPTION
I was not sure if I had to add translations where the term is the same in English, 
but I did so cause the others had done so.

After I made the translations I wanted to see how they looked in the actual interface, but it seems like there is 
no code for actually setting the language, I believe we can use: https://crates.io/crates/sys-locale to detect the current language one the system.

I added 
```rs
#[rustfmt::skip]
```
so that you can run rustfmt to format the repo without this generated code jumping around. I have noticed that a lot of source files are not formated using rustfmt (annoying if I want to modify code since my editor will format the code and the diff will contain a lot of unrelated changes) Is there any other reason that files in the repo is not formated?