### PR TITLE
sync warning tooltip

### DIFF
--- a/crates/backend/src/syncing.rs
+++ b/crates/backend/src/syncing.rs
@@ -217,33 +217,36 @@ fn read_options_txt(path: &Path) -> FxHashMap<String, String> {
 }
 
 pub fn get_sync_state(sync_targets: &SyncTargets, instances: &mut BackendStateInstances, directories: &LauncherDirectories) -> std::io::Result<SyncState> {
-    let mut dot_minecraft_paths = Vec::new();
+    let mut syncable_instances: Vec<(Arc<str>, Arc<Path>)> = Vec::new();
 
     for instance in instances.instances.iter_mut() {
         if !instance.configuration.get().disable_file_syncing {
-            dot_minecraft_paths.push(instance.dot_minecraft_path.clone());
+            syncable_instances.push((instance.name.as_str().into(), instance.dot_minecraft_path.clone()));
         }
     }
 
-    let total = dot_minecraft_paths.len();
+    let total = syncable_instances.len();
     let mut entries = BTreeMap::default();
 
     for file_target in sync_targets.files.iter() {
         if let Some(safe_file_target) = SafePath::new(file_target) {
-            let mut cannot_sync_count = 0;
+            let mut cannot_sync_instances = Vec::new();
 
-            for dot_minecraft in &dot_minecraft_paths {
+            for (instance_name, dot_minecraft) in &syncable_instances {
                 let target = safe_file_target.to_path(dot_minecraft);
                 if target.is_dir() {
-                    cannot_sync_count += 1;
+                    cannot_sync_instances.push(instance_name.clone());
                 }
             }
+            cannot_sync_instances.sort_by_key(|name| name.to_ascii_lowercase());
+            let cannot_sync_count = cannot_sync_instances.len();
 
             entries.insert(file_target.clone(), SyncTargetState {
                 enabled: true,
                 is_file: true,
                 sync_count: total.saturating_sub(cannot_sync_count),
                 cannot_sync_count,
+                cannot_sync_instances,
             });
         } else {
             entries.insert(file_target.clone(), SyncTargetState {
@@ -251,6 +254,7 @@ pub fn get_sync_state(sync_targets: &SyncTargets, instances: &mut BackendStateIn
                 is_file: true,
                 sync_count: 0,
                 cannot_sync_count: total,
+                cannot_sync_instances: syncable_instances.iter().map(|(name, _)| name.clone()).collect(),
             });
         }
     }
@@ -272,6 +276,7 @@ pub fn get_sync_state(sync_targets: &SyncTargets, instances: &mut BackendStateIn
                 is_file: false,
                 sync_count: 0,
                 cannot_sync_count: total,
+                cannot_sync_instances: syncable_instances.iter().map(|(name, _)| name.clone()).collect(),
             });
             continue;
         };
@@ -279,23 +284,26 @@ pub fn get_sync_state(sync_targets: &SyncTargets, instances: &mut BackendStateIn
         let target_dir = safe_path.to_path(&directories.synced_dir);
 
         let mut sync_count = 0;
-        let mut cannot_sync_count = 0;
+        let mut cannot_sync_instances = Vec::new();
 
-        for dot_minecraft in &dot_minecraft_paths {
+        for (instance_name, dot_minecraft) in &syncable_instances {
             let path = safe_path.to_path(dot_minecraft);
 
             if linking::is_targeting(&target_dir, &path) {
                 sync_count += 1;
             } else if path.exists() && !is_empty_dir(&path) {
-                cannot_sync_count += 1;
+                cannot_sync_instances.push(instance_name.clone());
             }
         }
+        cannot_sync_instances.sort_by_key(|name| name.to_ascii_lowercase());
+        let cannot_sync_count = cannot_sync_instances.len();
 
         entries.insert(folder_target.clone(), SyncTargetState {
             enabled,
             is_file: false,
             sync_count,
             cannot_sync_count,
+            cannot_sync_instances,
         });
     }
 

--- a/crates/bridge/src/message.rs
+++ b/crates/bridge/src/message.rs
@@ -394,6 +394,7 @@ pub struct SyncTargetState {
     pub is_file: bool,
     pub sync_count: usize,
     pub cannot_sync_count: usize,
+    pub cannot_sync_instances: Vec<Arc<str>>,
 }
 
 #[derive(Debug)]

--- a/crates/frontend/src/pages/syncing_page.rs
+++ b/crates/frontend/src/pages/syncing_page.rs
@@ -79,6 +79,7 @@ impl SyncingPage {
 
         let disable_tooltip = t::instance::sync::already_exists(cannot_sync_count, &name);
         let backend_handle = self.backend_handle.clone();
+        let target_name = name.clone();
         let checkbox = Checkbox::new(name.clone())
             .label(label)
             .disabled(disabled)
@@ -87,14 +88,14 @@ impl SyncingPage {
             .on_click(cx.listener(move |page, value, _, cx| {
 
             backend_handle.send(MessageToBackend::SetSyncing {
-                target: name.clone(),
+                target: target_name.clone(),
                 is_file,
                 value: *value,
             });
 
-            page.loading.insert(name.clone());
+            page.loading.insert(target_name.clone());
             if page.pending.is_empty() {
-                page.pending.insert(name.clone());
+                page.pending.insert(target_name.clone());
                 page.update_sync_state(cx);
             }
         }));
@@ -110,10 +111,24 @@ impl SyncingPage {
                 );
             }
             if enabled && cannot_sync_count > 0 {
-                base = base.child(h_flex().gap_1().flex_shrink().text_color(warning)
-                    .child(PandoraIcon::TriangleAlert)
-                    .child(t::instance::sync::unable_count(cannot_sync_count, sync_state.total_count))
-                );
+                let cannot_sync_tooltip = if let Some(sync_target_state) = sync_state.targets.get(&name) {
+                    format!(
+                        "{}\n{}",
+                        t::instance::sync::unable_instances_tooltip(),
+                        sync_target_state.cannot_sync_instances.join("\n")
+                    )
+                } else {
+                    t::instance::sync::unable_instances_tooltip().to_string()
+                };
+                let warning_id = format!("cannot_sync_warning_{}", name);
+
+                base = base.child(Button::new(warning_id)
+                    .text()
+                    .text_color(warning)
+                    .compact()
+                    .icon(PandoraIcon::TriangleAlert)
+                    .label(t::instance::sync::unable_count(cannot_sync_count, sync_state.total_count))
+                    .tooltip(cannot_sync_tooltip));
             }
         }
 

--- a/crates/t/locales.toml
+++ b/crates/t/locales.toml
@@ -1381,6 +1381,10 @@ hu = "(${count: usize}/${total: usize} mappa szinkronizálva)"
 en = "${count: usize}/${total: usize} instances are unable to be synced!"
 de = "${count: usize}/${total: usize} Instanzen konnten nicht synchronisiert werden!"
 hu = "${count: usize}/${total: usize} példány nem szinkronizálható!"
+[instance.sync.unable_instances_tooltip]
+en = "Unable to sync for these instances:"
+de = "Kann für diese Instanzen nicht synchronisiert werden:"
+hu = "Ezeknél a példányoknál nem szinkronizálható:"
 [instance.sync.files]
 en = "Files"
 de = "Dateien"

--- a/crates/t/src/lib.rs
+++ b/crates/t/src/lib.rs
@@ -1870,6 +1870,7 @@ pub mod instance {
                 "open_folder" => Some(open_folder()),
                 "sync_file" => Some(sync_file()),
                 "sync_folder" => Some(sync_folder()),
+                "unable_instances_tooltip" => Some(unable_instances_tooltip()),
                 _ => None,
             }
         }
@@ -2111,6 +2112,13 @@ pub mod instance {
                 1 => format!("{count}/{total} Instanzen konnten nicht synchronisiert werden!"),
                 2 => format!("{count}/{total} példány nem szinkronizálható!"),
                 _ => format!("{count}/{total} instances are unable to be synced!"),
+            }
+        }
+        pub fn unable_instances_tooltip() -> &'static str {
+            match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
+                1 => "Kann für diese Instanzen nicht synchronisiert werden:",
+                2 => "Ezeknél a példányoknál nem szinkronizálható:",
+                _ => "Unable to sync for these instances:",
             }
         }
     }


### PR DESCRIPTION
Added a hover tooltip to tell you what instance failed to sync (out of personal annoyance more than anything)

<img width="816" height="203" alt="Screenshot 2026-05-12 094547" src="https://github.com/user-attachments/assets/1c81402f-072e-445c-8fe9-c7e615183712" />

closes https://github.com/Moulberry/PandoraLauncher/issues/437