### PR TITLE
Account reorder controls

### DIFF
--- a/crates/backend/src/account.rs
+++ b/crates/backend/src/account.rs
@@ -16,21 +16,50 @@ pub struct MinecraftLoginInfo {
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct BackendAccountInfo {
     pub accounts: FxHashMap<Uuid, BackendAccount>,
+    #[serde(default)]
+    pub account_order: Vec<Uuid>,
     pub selected_account: Option<Uuid>,
 }
 
 impl BackendAccountInfo {
+    pub fn ensure_account_order(&self) -> Vec<Uuid> {
+        let mut order = self.account_order.clone();
+        order.retain(|uuid| self.accounts.contains_key(uuid));
+
+        for uuid in self.accounts.keys() {
+            if !order.contains(uuid) {
+                order.push(*uuid);
+            }
+        }
+
+        if self.account_order.is_empty() {
+            order.sort_by(|a, b| {
+                let a_name = self.accounts.get(a).map(|a| a.username.as_ref()).unwrap_or("");
+                let b_name = self.accounts.get(b).map(|a| a.username.as_ref()).unwrap_or("");
+                lexical_sort::natural_lexical_cmp(a_name, b_name)
+            });
+        }
+
+        order
+    }
+
+    pub fn normalize_account_order(&mut self) {
+        self.account_order = self.ensure_account_order();
+    }
+
     pub fn create_update_message(&self) -> MessageToFrontend {
         let mut accounts = Vec::with_capacity(self.accounts.len());
-        for (uuid, account) in &self.accounts {
+        for uuid in self.ensure_account_order() {
+            let Some(account) = self.accounts.get(&uuid) else {
+                continue;
+            };
             accounts.push(Account {
-                uuid: *uuid,
+                uuid,
                 username: account.username.clone(),
                 offline: account.offline,
                 head: account.head.clone(),
             });
         }
-        accounts.sort_by(|a, b| lexical_sort::natural_lexical_cmp(&a.username, &b.username));
         MessageToFrontend::AccountsUpdated {
             accounts: accounts.into(),
             selected_account: self.selected_account,

--- a/crates/backend/src/backend.rs
+++ b/crates/backend/src/backend.rs
@@ -121,7 +121,10 @@ pub fn start(runtime: tokio::runtime::Runtime, launcher_dir: PathBuf, send: Fron
     state_file_watching.watch_filesystem(directories.root_launcher_dir.clone(), WatchTarget::RootDir);
 
     // Load accounts
-    let account_info = Persistent::load(directories.accounts_json.clone());
+    let mut account_info = Persistent::load(directories.accounts_json.clone());
+    account_info.modify(|account_info: &mut BackendAccountInfo| {
+        account_info.normalize_account_order();
+    });
 
     let state = BackendState {
         self_handle,

--- a/crates/backend/src/backend_handler.rs
+++ b/crates/backend/src/backend_handler.rs
@@ -1369,6 +1369,10 @@ impl BackendState {
                         offline: true,
                         head: None
                     });
+                    account_info.account_order.retain(|account_uuid| account_info.accounts.contains_key(account_uuid));
+                    if !account_info.account_order.contains(&uuid) {
+                        account_info.account_order.push(uuid);
+                    }
                     account_info.selected_account = Some(uuid);
                 });
             },
@@ -1389,9 +1393,28 @@ impl BackendState {
 
                 account_info.modify(|account_info| {
                     account_info.accounts.remove(&uuid);
+                    account_info.account_order.retain(|account_uuid| *account_uuid != uuid);
                     if account_info.selected_account == Some(uuid) {
                         account_info.selected_account = None;
                     }
+                });
+            },
+            MessageToBackend::ReorderAccounts { from_index, to_index } => {
+                let mut account_info = self.account_info.write();
+                account_info.modify(|account_info| {
+                    account_info.account_order.retain(|account_uuid| account_info.accounts.contains_key(account_uuid));
+                    for uuid in account_info.accounts.keys() {
+                        if !account_info.account_order.contains(uuid) {
+                            account_info.account_order.push(*uuid);
+                        }
+                    }
+
+                    if from_index >= account_info.account_order.len() || to_index >= account_info.account_order.len() || from_index == to_index {
+                        return;
+                    }
+
+                    let uuid = account_info.account_order.remove(from_index);
+                    account_info.account_order.insert(to_index, uuid);
                 });
             },
             MessageToBackend::SetOpenGameOutputAfterLaunching { value } => {
@@ -2246,6 +2269,7 @@ impl BackendState {
             if !info.accounts.contains_key(&profile.id) {
                 let account = BackendAccount::new_from_profile(profile);
                 info.accounts.insert(profile.id, account);
+                info.account_order.push(profile.id);
             }
 
             if select {

--- a/crates/backend/src/syncing.rs
+++ b/crates/backend/src/syncing.rs
@@ -217,33 +217,36 @@ fn read_options_txt(path: &Path) -> FxHashMap<String, String> {
 }
 
 pub fn get_sync_state(sync_targets: &SyncTargets, instances: &mut BackendStateInstances, directories: &LauncherDirectories) -> std::io::Result<SyncState> {
-    let mut dot_minecraft_paths = Vec::new();
+    let mut syncable_instances: Vec<(Arc<str>, Arc<Path>)> = Vec::new();
 
     for instance in instances.instances.iter_mut() {
         if !instance.configuration.get().disable_file_syncing {
-            dot_minecraft_paths.push(instance.dot_minecraft_path.clone());
+            syncable_instances.push((instance.name.as_str().into(), instance.dot_minecraft_path.clone()));
         }
     }
 
-    let total = dot_minecraft_paths.len();
+    let total = syncable_instances.len();
     let mut entries = BTreeMap::default();
 
     for file_target in sync_targets.files.iter() {
         if let Some(safe_file_target) = SafePath::new(file_target) {
-            let mut cannot_sync_count = 0;
+            let mut cannot_sync_instances = Vec::new();
 
-            for dot_minecraft in &dot_minecraft_paths {
+            for (instance_name, dot_minecraft) in &syncable_instances {
                 let target = safe_file_target.to_path(dot_minecraft);
                 if target.is_dir() {
-                    cannot_sync_count += 1;
+                    cannot_sync_instances.push(instance_name.clone());
                 }
             }
+            cannot_sync_instances.sort_by_key(|name| name.to_ascii_lowercase());
+            let cannot_sync_count = cannot_sync_instances.len();
 
             entries.insert(file_target.clone(), SyncTargetState {
                 enabled: true,
                 is_file: true,
                 sync_count: total.saturating_sub(cannot_sync_count),
                 cannot_sync_count,
+                cannot_sync_instances,
             });
         } else {
             entries.insert(file_target.clone(), SyncTargetState {
@@ -251,6 +254,7 @@ pub fn get_sync_state(sync_targets: &SyncTargets, instances: &mut BackendStateIn
                 is_file: true,
                 sync_count: 0,
                 cannot_sync_count: total,
+                cannot_sync_instances: syncable_instances.iter().map(|(name, _)| name.clone()).collect(),
             });
         }
     }
@@ -272,6 +276,7 @@ pub fn get_sync_state(sync_targets: &SyncTargets, instances: &mut BackendStateIn
                 is_file: false,
                 sync_count: 0,
                 cannot_sync_count: total,
+                cannot_sync_instances: syncable_instances.iter().map(|(name, _)| name.clone()).collect(),
             });
             continue;
         };
@@ -279,23 +284,26 @@ pub fn get_sync_state(sync_targets: &SyncTargets, instances: &mut BackendStateIn
         let target_dir = safe_path.to_path(&directories.synced_dir);
 
         let mut sync_count = 0;
-        let mut cannot_sync_count = 0;
+        let mut cannot_sync_instances = Vec::new();
 
-        for dot_minecraft in &dot_minecraft_paths {
+        for (instance_name, dot_minecraft) in &syncable_instances {
             let path = safe_path.to_path(dot_minecraft);
 
             if linking::is_targeting(&target_dir, &path) {
                 sync_count += 1;
             } else if path.exists() && !is_empty_dir(&path) {
-                cannot_sync_count += 1;
+                cannot_sync_instances.push(instance_name.clone());
             }
         }
+        cannot_sync_instances.sort_by_key(|name| name.to_ascii_lowercase());
+        let cannot_sync_count = cannot_sync_instances.len();
 
         entries.insert(folder_target.clone(), SyncTargetState {
             enabled,
             is_file: false,
             sync_count,
             cannot_sync_count,
+            cannot_sync_instances,
         });
     }
 

--- a/crates/bridge/src/message.rs
+++ b/crates/bridge/src/message.rs
@@ -394,6 +394,7 @@ pub struct SyncTargetState {
     pub is_file: bool,
     pub sync_count: usize,
     pub cannot_sync_count: usize,
+    pub cannot_sync_instances: Vec<Arc<str>>,
 }
 
 #[derive(Debug)]

--- a/crates/bridge/src/message.rs
+++ b/crates/bridge/src/message.rs
@@ -249,6 +249,10 @@ pub enum MessageToBackend {
     DeleteAccount {
         uuid: Uuid,
     },
+    ReorderAccounts {
+        from_index: usize,
+        to_index: usize,
+    },
     SetOpenGameOutputAfterLaunching {
         value: bool,
     },

--- a/crates/frontend/src/pages/syncing_page.rs
+++ b/crates/frontend/src/pages/syncing_page.rs
@@ -79,6 +79,7 @@ impl SyncingPage {
 
         let disable_tooltip = t::instance::sync::already_exists(cannot_sync_count, &name);
         let backend_handle = self.backend_handle.clone();
+        let target_name = name.clone();
         let checkbox = Checkbox::new(name.clone())
             .label(label)
             .disabled(disabled)
@@ -87,14 +88,14 @@ impl SyncingPage {
             .on_click(cx.listener(move |page, value, _, cx| {
 
             backend_handle.send(MessageToBackend::SetSyncing {
-                target: name.clone(),
+                target: target_name.clone(),
                 is_file,
                 value: *value,
             });
 
-            page.loading.insert(name.clone());
+            page.loading.insert(target_name.clone());
             if page.pending.is_empty() {
-                page.pending.insert(name.clone());
+                page.pending.insert(target_name.clone());
                 page.update_sync_state(cx);
             }
         }));
@@ -110,10 +111,24 @@ impl SyncingPage {
                 );
             }
             if enabled && cannot_sync_count > 0 {
-                base = base.child(h_flex().gap_1().flex_shrink().text_color(warning)
-                    .child(PandoraIcon::TriangleAlert)
-                    .child(t::instance::sync::unable_count(cannot_sync_count, sync_state.total_count))
-                );
+                let cannot_sync_tooltip = if let Some(sync_target_state) = sync_state.targets.get(&name) {
+                    format!(
+                        "{}\n{}",
+                        t::instance::sync::unable_instances_tooltip(),
+                        sync_target_state.cannot_sync_instances.join("\n")
+                    )
+                } else {
+                    t::instance::sync::unable_instances_tooltip().to_string()
+                };
+                let warning_id = format!("cannot_sync_warning_{}", name);
+
+                base = base.child(Button::new(warning_id)
+                    .text()
+                    .text_color(warning)
+                    .compact()
+                    .icon(PandoraIcon::TriangleAlert)
+                    .label(t::instance::sync::unable_count(cannot_sync_count, sync_state.total_count))
+                    .tooltip(cannot_sync_tooltip));
             }
         }
 

--- a/crates/frontend/src/ui.rs
+++ b/crates/frontend/src/ui.rs
@@ -522,7 +522,8 @@ impl Render for LauncherUI {
                             (accounts.accounts.clone(), accounts.selected_account_uuid)
                         };
 
-                        let items = accounts.iter().map(|account| {
+                        let accounts_len = accounts.len();
+                        let items = accounts.iter().enumerate().map(|(account_index, account)| {
                             let head = if hide_skins {
                                 gpui::img(ImageSource::Resource(Resource::Embedded("images/hidden_head.png".into())))
                             } else if let Some(head) = &account.head {
@@ -556,7 +557,45 @@ impl Render for LauncherUI {
                                             }
                                         })
                                     }))
-                                .child(Button::new((account_name.clone(), 1))
+                                .child(v_flex()
+                                    .gap_1()
+                                    .child(Button::new(("account-up", account_index))
+                                        .compact()
+                                        .h_5()
+                                        .w_8()
+                                        .icon(PandoraIcon::ArrowUp)
+                                        .disabled(account_index == 0)
+                                        .on_click({
+                                            let backend_handle = backend_handle.clone();
+                                            move |_, _, _| {
+                                                if account_index == 0 {
+                                                    return;
+                                                }
+                                                backend_handle.send(MessageToBackend::ReorderAccounts {
+                                                    from_index: account_index,
+                                                    to_index: account_index - 1,
+                                                });
+                                            }
+                                        }))
+                                    .child(Button::new(("account-down", account_index))
+                                        .compact()
+                                        .h_5()
+                                        .w_8()
+                                        .icon(PandoraIcon::ArrowDown)
+                                        .disabled(account_index + 1 >= accounts_len)
+                                        .on_click({
+                                            let backend_handle = backend_handle.clone();
+                                            move |_, _, _| {
+                                                if account_index + 1 >= accounts_len {
+                                                    return;
+                                                }
+                                                backend_handle.send(MessageToBackend::ReorderAccounts {
+                                                    from_index: account_index,
+                                                    to_index: account_index + 1,
+                                                });
+                                            }
+                                        })))
+                                .child(Button::new(("account-delete", account_index))
                                     .icon(PandoraIcon::Trash2)
                                     .h_10()
                                     .w_10()

--- a/crates/t/locales.toml
+++ b/crates/t/locales.toml
@@ -1381,6 +1381,10 @@ hu = "(${count: usize}/${total: usize} mappa szinkronizálva)"
 en = "${count: usize}/${total: usize} instances are unable to be synced!"
 de = "${count: usize}/${total: usize} Instanzen konnten nicht synchronisiert werden!"
 hu = "${count: usize}/${total: usize} példány nem szinkronizálható!"
+[instance.sync.unable_instances_tooltip]
+en = "Unable to sync for these instances:"
+de = "Kann für diese Instanzen nicht synchronisiert werden:"
+hu = "Ezeknél a példányoknál nem szinkronizálható:"
 [instance.sync.files]
 en = "Files"
 de = "Dateien"

--- a/crates/t/src/lib.rs
+++ b/crates/t/src/lib.rs
@@ -1870,6 +1870,7 @@ pub mod instance {
                 "open_folder" => Some(open_folder()),
                 "sync_file" => Some(sync_file()),
                 "sync_folder" => Some(sync_folder()),
+                "unable_instances_tooltip" => Some(unable_instances_tooltip()),
                 _ => None,
             }
         }
@@ -2111,6 +2112,13 @@ pub mod instance {
                 1 => format!("{count}/{total} Instanzen konnten nicht synchronisiert werden!"),
                 2 => format!("{count}/{total} példány nem szinkronizálható!"),
                 _ => format!("{count}/{total} instances are unable to be synced!"),
+            }
+        }
+        pub fn unable_instances_tooltip() -> &'static str {
+            match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
+                1 => "Kann für diese Instanzen nicht synchronisiert werden:",
+                2 => "Ezeknél a példányoknál nem szinkronizálható:",
+                _ => "Unable to sync for these instances:",
             }
         }
     }


### PR DESCRIPTION
QoL feature, adding reorder controls to the accounts panel
Accounts now keep a saved order (with migration for old `accounts.json`), new accounts append to the bottom.

<img width="344" height="440" alt="Screenshot 2026-05-12 100941" src="https://github.com/user-attachments/assets/30463a93-d8ae-4437-96e5-6060ef62530b" />

Closes https://github.com/Moulberry/PandoraLauncher/issues/424