### PR TITLE
fix: Forward XAUTHORITY on bwrap sandboxing

### DIFF
--- a/crates/command/src/unix/linux/bwrap.rs
+++ b/crates/command/src/unix/linux/bwrap.rs
@@ -76,6 +76,7 @@ static ALLOWED_ENV_VARS: Lazy<FxHashSet<&'static OsStr>> = Lazy::new(|| {
         "USER",
         "USERNAME",
         "DISPLAY",
+        "XAUTHORITY",
         "WAYLAND_DISPLAY",
         "PULSE_SERVER"
     ].iter().map(OsStr::new).collect()


### PR DESCRIPTION
The sandbox adds the path for XAUTHORITY (if set) but doesn't forward the variable, leading to failure to create the display if it is set.

I've been working on getting the sandbox to work on NixOS, and found that this was leading to failure on creating the display. Since it seems to be an issue that could affect more then just NixOS users I though I should make this a PR