### PR TITLE
fix(sandbox): bind NVIDIA linux kernel module sysfs for driver init in user namespace

### DIFF
--- a/crates/command/src/unix/linux/bwrap.rs
+++ b/crates/command/src/unix/linux/bwrap.rs
@@ -62,6 +62,11 @@ const SYSTEM_FILES_RO: &[&str] = &[
     "/sys/class/hwmon",
     "/sys/class/thermal",
     "/sys/class/drm",
+    // NVIDIA kernel module state (needed for driver init in user ns)
+    "/sys/module/nvidia",
+    "/sys/module/nvidia_drm",
+    "/sys/module/nvidia_modeset",
+    "/sys/module/nvidia_uvm",
 ];
 
 static ALLOWED_ENV_VARS: Lazy<FxHashSet<&'static OsStr>> = Lazy::new(|| {


### PR DESCRIPTION
Bind the following directories into the sandbox as read-only: `/sys/module/nvidia`, `/sys/module/nvidia_drm`, `/sys/module/nvidia_modeset`, and `/sys/module/nvidia_uvm` - source https://github.com/systemd/systemd/issues/38018#issuecomment-3115306143

Fixes #384 