### PR TITLE
Make bwrap work under nixos

### DIFF
--- a/crates/command/src/unix/linux/bwrap.rs
+++ b/crates/command/src/unix/linux/bwrap.rs
@@ -62,6 +62,9 @@ const SYSTEM_FILES_RO: &[&str] = &[
     "/sys/class/hwmon",
     "/sys/class/thermal",
     "/sys/class/drm",
+    "/nix/store",
+    "/run/opengl-driver",
+    "/run/opengl-driver-32",
 ];
 
 static ALLOWED_ENV_VARS: Lazy<FxHashSet<&'static OsStr>> = Lazy::new(|| {
@@ -77,7 +80,8 @@ static ALLOWED_ENV_VARS: Lazy<FxHashSet<&'static OsStr>> = Lazy::new(|| {
         "USERNAME",
         "DISPLAY",
         "WAYLAND_DISPLAY",
-        "PULSE_SERVER"
+        "PULSE_SERVER",
+        "LD_LIBRARY_PATH",
     ].iter().map(OsStr::new).collect()
 });
 


### PR DESCRIPTION
I do not know if this is the ideal way to do things, but it does work

`/nix/store` is generally considered world readable, though some nixos users may put secrets in it regardless, so maybe theres some nicer solution than to bind the entire store?
Just binding the executable itself is not enough though, it results in something like
`bwrap: execvp /home/tomate/Documents/projects/launcher/tmp/hello: No such file or directory`
so you would at least need to also bind glibc ("/nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61" in this case) for anything to even run at all 

Without `LD_LIBRARY_PATH` you would get
<img width="891" height="529" alt="screenshot-2026-06-23_16-22-28" src="https://github.com/user-attachments/assets/0dd3a50c-e3e9-4874-81c5-6604e8477231" />

And without `/run/opengl-driver` (which also seems to contain stuff necessary for vulkan) you would get
<img width="408" height="150" alt="screenshot-2026-06-23_16-20-07" src="https://github.com/user-attachments/assets/cee019f3-d45a-4fcb-a617-e315dfd686f6" />

