### PR TITLE
Extract `format_downloads` to lib, reuse on pages

### DIFF
--- a/crates/frontend/src/lib.rs
+++ b/crates/frontend/src/lib.rs
@@ -332,3 +332,15 @@ pub(crate) fn open_folder(path: &Path, window: &mut Window, cx: &mut App) {
         window.push_notification(notification.autohide(false), cx);
     }
 }
+
+pub fn format_downloads(downloads: u64) -> SharedString {
+    if downloads >= 1_000_000_000 {
+        t::instance::content::downloads::b((downloads / 10_000_000) as f64 / 100.0)
+    } else if downloads >= 1_000_000 {
+        t::instance::content::downloads::m((downloads / 10_000) as f64 / 100.0)
+    } else if downloads >= 10_000 {
+        t::instance::content::downloads::k((downloads / 10) as f64 / 100.0)
+    } else {
+        t::instance::content::downloads::n(downloads)
+    }.into()
+}

--- a/crates/frontend/src/pages/curseforge_page.rs
+++ b/crates/frontend/src/pages/curseforge_page.rs
@@ -14,7 +14,7 @@ use ustr::Ustr;
 use crate::{
     component::error_alert::ErrorAlert, entity::{
         DataEntities, instance::ContentStates, metadata::{AsMetadataResult, FrontendMetadata, FrontendMetadataResult}
-    }, icon::PandoraIcon, interface_config::InterfaceConfig, pages::page::Page,
+    }, icon::PandoraIcon, interface_config::InterfaceConfig, pages::page::Page, format_downloads
 };
 
 pub struct CurseforgeSearchPage {
@@ -919,18 +919,6 @@ impl Render for CurseforgeSearchPage {
 
         h_flex().flex_1().min_h_0().size_full().child(parameters).child(content)
     }
-}
-
-pub fn format_downloads(downloads: u64) -> SharedString {
-    if downloads >= 1_000_000_000 {
-        t::instance::content::downloads::b((downloads / 10_000_000) as f64 / 100.0)
-    } else if downloads >= 1_000_000 {
-        t::instance::content::downloads::m((downloads / 10_000) as f64 / 100.0)
-    } else if downloads >= 10_000 {
-        t::instance::content::downloads::k((downloads / 10) as f64 / 100.0)
-    } else {
-        t::instance::content::downloads::n(downloads)
-    }.into()
 }
 
 const FILTER_MOD_CATEGORIES: &[(&'static str, u32)] = &[

--- a/crates/frontend/src/pages/modrinth_page.rs
+++ b/crates/frontend/src/pages/modrinth_page.rs
@@ -16,7 +16,7 @@ use strum::IntoEnumIterator;
 use crate::{
     component::error_alert::ErrorAlert, entity::{
         DataEntities, instance::ContentStates, metadata::{AsMetadataResult, FrontendMetadata, FrontendMetadataResult}
-    }, icon::PandoraIcon, interface_config::InterfaceConfig, pages::page::Page, ui
+    }, icon::PandoraIcon, interface_config::InterfaceConfig, pages::page::Page, ui, format_downloads
 };
 
 pub struct ModrinthSearchPage {
@@ -996,18 +996,6 @@ impl Render for ModrinthSearchPage {
 
         h_flex().flex_1().min_h_0().size_full().child(parameters).child(content)
     }
-}
-
-pub fn format_downloads(downloads: u64) -> SharedString {
-    if downloads >= 1_000_000_000 {
-        t::instance::content::downloads::b((downloads / 10_000_000) as f64 / 100.0)
-    } else if downloads >= 1_000_000 {
-        t::instance::content::downloads::m((downloads / 10_000) as f64 / 100.0)
-    } else if downloads >= 10_000 {
-        t::instance::content::downloads::k((downloads / 10) as f64 / 100.0)
-    } else {
-        t::instance::content::downloads::n(downloads)
-    }.into()
 }
 
 pub fn icon_for(str: &str) -> Option<&'static str> {

--- a/crates/frontend/src/pages/modrinth_project_page.rs
+++ b/crates/frontend/src/pages/modrinth_project_page.rs
@@ -13,7 +13,7 @@ use strum::IntoEnumIterator;
 use crate::{
     component::error_alert::ErrorAlert, entity::{
         DataEntities, instance::ContentStates, metadata::{AsMetadataResult, FrontendMetadata, FrontendMetadataResult}
-    }, icon::PandoraIcon, pages::modrinth_page::{InstalledContent, PrimaryAction, env_display, format_downloads, get_primary_action, icon_for}
+    }, icon::PandoraIcon, pages::modrinth_page::{InstalledContent, PrimaryAction, env_display, get_primary_action, icon_for}, format_downloads
 };
 
 pub struct ModrinthProjectPage {


### PR DESCRIPTION
# Why

Spotted that exact same `format_downloads` helper is defined in two pages code.

# How

Extract `format_downloads` to crate lib, reuse on pages.