### PR TITLE
Slightly deemphasize mod lists entries tags

### DIFF
--- a/crates/frontend/src/pages/curseforge_page.rs
+++ b/crates/frontend/src/pages/curseforge_page.rs
@@ -476,10 +476,10 @@ impl CurseforgeSearchPage {
 
                 let name = SharedString::new(hit.name.clone());
                 let description = SharedString::new(hit.summary.clone());
+                let tag_separator = SharedString::new("•");
 
-                let author_line = div().text_color(cx.theme().muted_foreground).text_sm().pb_px().child(author);
+                let author_line = div().text_color(theme.muted_foreground).text_sm().pb_px().child(author);
 
-                let muted = cx.theme().muted_foreground;
                 let mut is_categories_empty = true;
                 let categories = hit.categories.iter().filter_map(|category| {
                     if category.is_class {
@@ -489,10 +489,10 @@ impl CurseforgeSearchPage {
                     Some(SharedString::new(category.name.clone()).into_any_element())
                 });
                 let categories = itertools::Itertools::intersperse_with(categories,
-                    || div().flex_shrink_0().w_px().h_1_2().bg(muted).into_any_element());
+                    || div().flex_shrink_0().child(tag_separator.clone()).into_any_element());
 
                 let downloads = h_flex()
-                    .gap_0p5()
+                    .gap_1()
                     .child(PandoraIcon::Download)
                     .child(format_downloads(hit.download_count));
 
@@ -629,7 +629,9 @@ impl CurseforgeSearchPage {
                             )
                             .child(
                                 h_flex()
-                                    .gap_2p5()
+                                    .text_sm()
+                                    .text_color(theme.muted_foreground)
+                                    .gap_1()
                                     .child(PandoraIcon::Tags)
                                     .children(categories),
                             ),

--- a/crates/frontend/src/pages/modrinth_page.rs
+++ b/crates/frontend/src/pages/modrinth_page.rs
@@ -493,7 +493,7 @@ impl ModrinthSearchPage {
                     .map(SharedString::new)
                     .unwrap_or(t::instance::content::no_description().into());
 
-                let author_line = div().text_color(cx.theme().muted_foreground).text_sm().pb_px().child(author);
+                let author_line = div().text_color(theme.muted_foreground).text_sm().pb_px().child(author);
 
                 let client_side = hit.client_side.unwrap_or(ModrinthSideRequirement::Unknown);
                 let server_side = hit.server_side.unwrap_or(ModrinthSideRequirement::Unknown);
@@ -512,12 +512,12 @@ impl ModrinthSearchPage {
                         let icon = Icon::empty().path(icon);
                         let translated_category = t::modrinth::category::get(category, false)
                             .unwrap_or("missing_translation");
-                        Some(h_flex().gap_0p5().child(icon).child(translated_category))
+                        Some(h_flex().gap_1().child(icon).child(translated_category))
                     })
                 });
 
                 let downloads = h_flex()
-                    .gap_0p5()
+                    .gap_1()
                     .child(PandoraIcon::Download)
                     .child(format_downloads(hit.downloads));
 
@@ -626,6 +626,8 @@ impl ModrinthSearchPage {
                             .child(
                                 h_flex()
                                     .text_decoration_0()
+                                    .text_sm()
+                                    .text_color(theme.muted_foreground)
                                     .gap_2p5()
                                     .children(std::iter::once(environment).chain(categories)),
                             ),


### PR DESCRIPTION
# Why

It seems for me that there is not enough contrast between mod lists entries content, and everything seems to blend into continuous text wall.

# How

Slightly deemphasize mod lists entries tags by reducing font size and applying muted foreground color. As a part of the changes I have also tweaked spacing a bit, switched the Curseforge tags separator to bullet character, and used already locally defined `theme` where possible.

# Preview

<img width="1414" height="900" alt="Screenshot 2026-06-28 at 18 46 00" src="https://github.com/user-attachments/assets/614acc5d-a327-4ab2-b530-f920eafe78c8" />
<img width="1414" height="900" alt="Screenshot 2026-06-28 at 18 46 10" src="https://github.com/user-attachments/assets/72ec6fac-b3c4-4639-b94e-00674b2772bd" />
