### PR TITLE
Fix skins menu scroll not working

### DIFF
--- a/crates/frontend/src/pages/skins_page.rs
+++ b/crates/frontend/src/pages/skins_page.rs
@@ -193,7 +193,6 @@ impl Render for SkinsPage {
         let mut library = v_flex()
             .flex_1()
             .min_w_0()
-            .overflow_hidden()
             .w_full()
             .text_xl()
             .content_start()


### PR DESCRIPTION
This single line change fixes a bug that prevents skin library from scrolling when there are a lot of skins.

Before (no scrollbar and doesn't react to mouse wheel):
<img src="https://github.com/user-attachments/assets/79dae997-2bf1-4e5c-8856-6de5e7c2b8ff" />

After (can scroll):
<img src="https://github.com/user-attachments/assets/41d42f93-cb5d-4b1f-8471-11ed64b2831d" />