### PR TITLE
Use text ellipsis on mod description

### DIFF
--- a/crates/frontend/src/pages/curseforge_page.rs
+++ b/crates/frontend/src/pages/curseforge_page.rs
@@ -625,6 +625,7 @@ impl CurseforgeSearchPage {
                                     .flex_auto()
                                     .line_height(px(20.0))
                                     .line_clamp(2)
+                                    .text_ellipsis()
                                     .child(description),
                             )
                             .child(

--- a/crates/frontend/src/pages/modrinth_page.rs
+++ b/crates/frontend/src/pages/modrinth_page.rs
@@ -621,6 +621,7 @@ impl ModrinthSearchPage {
                                     .flex_auto()
                                     .line_height(px(20.0))
                                     .line_clamp(2)
+                                    .text_ellipsis()
                                     .child(description),
                             )
                             .child(


### PR DESCRIPTION
# How

Use text ellipsis on mod description, it does not always work correctly with current tile layout, but still it feels better than the overflow cutoff.

# Preview

### Before

<img width="1417" height="860" alt="Screenshot 2026-07-04 at 11 34 13" src="https://github.com/user-attachments/assets/a40653b6-43e6-46c7-b459-ae319774d112" />

### After

<img width="1417" height="860" alt="Screenshot 2026-07-04 at 11 33 49" src="https://github.com/user-attachments/assets/e884c60a-7faf-46a0-baf7-215d68563e7d" />
