### PR TITLE
Convert requesting error message to accept service name

### DIFF
--- a/crates/frontend/src/modals/modrinth_install.rs
+++ b/crates/frontend/src/modals/modrinth_install.rs
@@ -273,7 +273,7 @@ fn open_from_entity(
         },
         FrontendMetadataResult::Error(message) => {
             window.open_dialog(cx, move |modal, _, _| {
-                modal.title(title.clone()).child(ErrorAlert::new(t::instance::content::requesting_from_modrinth_error().into(), message.clone()))
+                modal.title(title.clone()).child(ErrorAlert::new(t::instance::content::requesting_from_error("Modrinth").into(), message.clone()))
             });
         },
     }

--- a/crates/frontend/src/pages/curseforge_page.rs
+++ b/crates/frontend/src/pages/curseforge_page.rs
@@ -438,7 +438,7 @@ impl CurseforgeSearchPage {
                         return div()
                             .pl_3()
                             .pt_3()
-                            .child(ErrorAlert::new(t::instance::content::requesting_from_modrinth_error().into(), search_error));
+                            .child(ErrorAlert::new(t::instance::content::requesting_from_error("Curseforge").into(), search_error));
                     } else {
                         should_load_more = true;
                         return div()

--- a/crates/frontend/src/pages/modrinth_page.rs
+++ b/crates/frontend/src/pages/modrinth_page.rs
@@ -459,7 +459,7 @@ impl ModrinthSearchPage {
                         return div()
                             .pl_3()
                             .pt_3()
-                            .child(ErrorAlert::new(t::instance::content::requesting_from_modrinth_error().into(), search_error));
+                            .child(ErrorAlert::new(t::instance::content::requesting_from_error("Modrinth").into(), search_error));
                     } else {
                         should_load_more = true;
                         return div()

--- a/crates/t/locales.toml
+++ b/crates/t/locales.toml
@@ -1388,11 +1388,11 @@ en = "Search..."
 de = "Suche..."
 hu = "Keresés..."
 sv = "Sök..."
-[instance.content.requesting_from_modrinth_error]
-en = "Error requesting from Modrinth"
-de = "Fehler beim Abrufen von Modrinth"
-hu = "Hiba a Modrinth lekérése közben"
-sv = "Fel vid hämtning från Modrinth"
+[instance.content.requesting_from_error]
+en = "Error requesting from ${service: &str}"
+de = "Fehler beim Abrufen von ${service: &str}"
+hu = "Hiba a ${service: &str} lekérése közben"
+sv = "Fel vid hämtning från ${service: &str}"
 [instance.content.unnamed]
 en = "Unnamed"
 de = "Unbenannt"

--- a/crates/t/src/lib.rs
+++ b/crates/t/src/lib.rs
@@ -510,7 +510,6 @@ pub mod instance {
                 "no_description" => Some(no_description()),
                 "no_gallery" => Some(no_gallery()),
                 "open_page" => Some(open_page()),
-                "requesting_from_modrinth_error" => Some(requesting_from_modrinth_error()),
                 "resourcepacks" => Some(resourcepacks()),
                 "shaders" => Some(shaders()),
                 "sort" => Some(sort()),
@@ -1006,12 +1005,12 @@ pub mod instance {
                 _ => "Open Page",
             }
         }
-        pub fn requesting_from_modrinth_error() -> &'static str {
+        pub fn requesting_from_error(service: &str) -> String {
             match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
-                1 => "Fehler beim Abrufen von Modrinth",
-                2 => "Hiba a Modrinth lekérése közben",
-                3 => "Fel vid hämtning från Modrinth",
-                _ => "Error requesting from Modrinth",
+                1 => format!("Fehler beim Abrufen von {service}"),
+                2 => format!("Hiba a {service} lekérése közben"),
+                3 => format!("Fel vid hämtning från {service}"),
+                _ => format!("Error requesting from {service}"),
             }
         }
         pub fn resourcepacks() -> &'static str {


### PR DESCRIPTION
# How

Spotted that Curseforge mod fetch uses error message with Modrinth hardcoded in it. This PR converts requesting error message to accept service name, and updated its usages.

# Preview

<img width="1417" height="860" alt="Screenshot 2026-07-04 at 12 35 52" src="https://github.com/user-attachments/assets/7bf9ef14-374f-4034-a48e-c880271aed94" />
