### PR TITLE
Skins menu enhancements

### DIFF
--- a/crates/frontend/src/component/player_model_widget.rs
+++ b/crates/frontend/src/component/player_model_widget.rs
@@ -183,6 +183,7 @@ impl Render for PlayerModelWidget {
             .h_full()
             .child(v_flex()
                 .size_full()
+                .items_center()
                 .id("player_model_widget")
                 .child(PlayerModel::new(&self.player_model_state))
                 .cursor_grab()

--- a/crates/frontend/src/interface_config.rs
+++ b/crates/frontend/src/interface_config.rs
@@ -72,6 +72,8 @@ pub struct InterfaceConfig {
     pub instance_subpage: InstanceSubpageType,
     #[serde(default, deserialize_with = "schema::try_deserialize")]
     pub collapse_capes_in_skins_page: bool,
+    #[serde(default, deserialize_with = "schema::try_deserialize")]
+    pub skin_list_sort_desc: bool,
     #[serde(default = "schema::default_true", deserialize_with = "schema::try_deserialize")]
     pub skin_list_show_3d: bool,
 }
@@ -163,6 +165,7 @@ impl Default for InterfaceConfig {
             instances_view_mode: Default::default(),
             instance_subpage: Default::default(),
             collapse_capes_in_skins_page: false,
+            skin_list_sort_desc: false,
             skin_list_show_3d: true,
         }
     }

--- a/crates/frontend/src/pages/skins_page.rs
+++ b/crates/frontend/src/pages/skins_page.rs
@@ -327,6 +327,7 @@ impl Render for SkinsPage {
                         library = library
                             .child(h_flex()
                                 .id("toggle-capes")
+                                .mb_4()
                                 .child(t::skins::capes())
                                 .child(PandoraIcon::ChevronLeft)
                                 .on_click(|_, _, cx| {
@@ -401,6 +402,7 @@ impl Render for SkinsPage {
                         library = library
                             .child(h_flex()
                                 .id("toggle-capes")
+                                .mb_1()
                                 .child(t::skins::capes())
                                 .child(PandoraIcon::ChevronDown)
                                 .on_click(|_, _, cx| {
@@ -429,8 +431,8 @@ impl Render for SkinsPage {
             .child(h_flex()
                 .flex_wrap()
                 .gap_x_3()
-                .gap_y_1()
-                .mb_1()
+                .gap_y_2()
+                .mb_2()
                 .child(h_flex().max_h_6().child(t::skins::title()))
                 .child(Button::new("add-file")
                     .label(t::skins::add_from_file())
@@ -691,7 +693,7 @@ impl Render for SkinsPage {
         h_flex().p_4()
             .gap_4()
             .child(v_flex()
-                .gap_2()
+                .gap_4()
                 .h_full()
                 .child(controls)
                 .child(self.player_model_widget.clone()))

--- a/crates/frontend/src/pages/skins_page.rs
+++ b/crates/frontend/src/pages/skins_page.rs
@@ -676,7 +676,18 @@ impl Render for SkinsPage {
                     .h_full()
                     .child(controls)
                     .child(self.player_model_widget.clone()))
-            .child(library.overflow_y_scrollbar())
+            .child(library
+                .overflow_y_scrollbar()
+                .drag_over(|style, _: &ExternalPaths, _, cx| {
+                    style.bg(cx.theme().accent.opacity(0.5))
+                })
+                .on_drop(cx.listener(|page, paths: &ExternalPaths, _window, _cx| {
+                    for path in paths.paths() {
+                        page.data.backend_handle.send(MessageToBackend::AddToSkinLibrary {
+                            source: UrlOrFile::File { path: path.clone() }
+                        });
+                    }
+                })))
             .overflow_hidden()
     }
 }

--- a/crates/frontend/src/pages/skins_page.rs
+++ b/crates/frontend/src/pages/skins_page.rs
@@ -624,7 +624,6 @@ impl Render for SkinsPage {
                 Some(div()
                     .id(("select-skin", i))
                     .rounded(radius)
-                    .mb_4()
                     .text_base()
                     .p(padding)
                     .size(px(144.0))

--- a/crates/frontend/src/pages/skins_page.rs
+++ b/crates/frontend/src/pages/skins_page.rs
@@ -13,6 +13,7 @@ use uuid::Uuid;
 use crate::{
     component::{player_model_widget::PlayerModelWidget, shrinking_text::ShrinkingText}, data_asset_loader::DataAssetLoader, entity::{DataEntities, account::AccountExt}, icon::PandoraIcon, interface_config::InterfaceConfig, pages::page::Page, png_render_cache::ImageTransformation, skin_thumbnail_cache::SkinThumbnailCache, skin_renderer::determine_skin_variant,
 };
+use itertools::Either;
 
 pub struct SkinsPage {
     account_skins: FxHashMap<Uuid, AccountSkinResult>,
@@ -414,7 +415,14 @@ impl Render for SkinsPage {
         }
 
         let skin_library = self.data.use_skin_library(cx).cloned();
-        let skin_library_iter = skin_library.iter().map(|l| l.skins.iter()).flatten();
+        let sort_descending = InterfaceConfig::get(cx).skin_list_sort_desc;
+        let skin_library_iter = skin_library.iter().flat_map(|l| {
+            if sort_descending {
+                Either::Left(l.skins.iter().rev())
+            } else {
+                Either::Right(l.skins.iter())
+            }
+        });
         let skins = active_skin.iter().chain(skin_library_iter).enumerate();
 
         library = library
@@ -546,6 +554,14 @@ impl Render for SkinsPage {
                             crate::open_folder(&folder, window, cx);
                         })
                     }))
+                .child(Button::new("toggle-sort")
+                    .icon(if InterfaceConfig::get(cx).skin_list_sort_desc { PandoraIcon::SortDescending } else { PandoraIcon::SortAscending })
+                    .label(if InterfaceConfig::get(cx).skin_list_sort_desc { t::skins::sort::newest_first() } else { t::skins::sort::oldest_first() })
+                    .small()
+                    .compact()
+                    .on_click(cx.listener(|_, _, _, cx| {
+                        InterfaceConfig::get_mut(cx).skin_list_sort_desc ^= true;
+                    })))
                 .child(Button::new("toggle-3d")
                     .icon(if InterfaceConfig::get(cx).skin_list_show_3d { PandoraIcon::Image } else { PandoraIcon::Box })
                     .label(if InterfaceConfig::get(cx).skin_list_show_3d { t::skins::switch_view::texture() } else { t::skins::switch_view::model() })

--- a/crates/frontend/src/pages/skins_page.rs
+++ b/crates/frontend/src/pages/skins_page.rs
@@ -691,10 +691,10 @@ impl Render for SkinsPage {
         h_flex().p_4()
             .gap_4()
             .child(v_flex()
-                    .gap_2()
-                    .h_full()
-                    .child(controls)
-                    .child(self.player_model_widget.clone()))
+                .gap_2()
+                .h_full()
+                .child(controls)
+                .child(self.player_model_widget.clone()))
             .child(library
                 .overflow_y_scrollbar()
                 .drag_over(|style, _: &ExternalPaths, _, cx| {

--- a/crates/frontend/src/pages/skins_page.rs
+++ b/crates/frontend/src/pages/skins_page.rs
@@ -627,6 +627,10 @@ impl Render for SkinsPage {
                     .mb_4()
                     .text_base()
                     .p(padding)
+                    .size(px(144.0))
+                    .flex()
+                    .items_center()
+                    .justify_center()
                     .when_else(selected, |this| {
                         this.bg(list_active)
                             .border_1()

--- a/crates/t/locales.toml
+++ b/crates/t/locales.toml
@@ -2092,6 +2092,10 @@ en = "Open folder"
 de = "Öffne Ordner"
 hu = "Mappa megnyitása"
 sv = "Öppna folder"
+[skins.sort.oldest_first]
+en = "Oldest first"
+[skins.sort.newest_first]
+en = "Newest first"
 [skins.switch_view.texture]
 en = "Switch to texture"
 de = "Wechsle zu Textur"

--- a/crates/t/src/lib.rs
+++ b/crates/t/src/lib.rs
@@ -3976,6 +3976,26 @@ pub mod skins {
         }
     }
     #[rustfmt::skip]
+    pub mod sort {
+        pub fn get(key: &str) -> Option<&'static str> {
+            match key {
+                "newest_first" => Some(newest_first()),
+                "oldest_first" => Some(oldest_first()),
+                _ => None,
+            }
+        }
+        pub fn newest_first() -> &'static str {
+            match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
+                _ => "Newest first",
+            }
+        }
+        pub fn oldest_first() -> &'static str {
+            match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
+                _ => "Oldest first",
+            }
+        }
+    }
+    #[rustfmt::skip]
     pub mod switch_view {
         pub fn get(key: &str) -> Option<&'static str> {
             match key {


### PR DESCRIPTION
- Can now add skins via drag-and-drop
  <img width="1205" height="708" src="https://github.com/user-attachments/assets/3f830073-f37f-4e0c-ac62-6c509a6c4f6a" />

- Can change sort order (currenty selected skin is always first)
  <img width="1060" height="42" src="https://github.com/user-attachments/assets/78e2b81b-7302-4041-899a-0c7b44d5ad7e" />
  <img width="1060" height="40" src="https://github.com/user-attachments/assets/2a7e826c-a3f1-411e-9b3b-8aca0343433f" />

- Fixed wrong card size of 64x32 skins in texture mode and redundant spacing between rows
  Before
  <img width="1148" height="606" src="https://github.com/user-attachments/assets/19d0276c-dede-48d9-91cf-ab0e32831c3a" />
  After
  <img width="1148" height="608" src="https://github.com/user-attachments/assets/58c9bdda-dc3a-4970-9857-be86604c856d" />

- Made player model centered, this is visible when window is small (before/after)
  <img width="300" height="520" src="https://github.com/user-attachments/assets/24842789-ddd7-4095-a4a6-7c1f0325a0bb" /> <img width="300" height="520" src="https://github.com/user-attachments/assets/8824632d-00bc-43b0-9ba9-ea18b3f713cb" />