### PR TITLE
Fix instance export on Windows

### DIFF
--- a/crates/backend/src/export.rs
+++ b/crates/backend/src/export.rs
@@ -485,7 +485,7 @@ fn ends_with_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
         return false;
     }
     let start = haystack.len() - needle.len();
-    haystack[start..].eq_ignore_ascii_case(needle)
+    haystack.as_bytes()[start..].eq_ignore_ascii_case(needle.as_bytes())
 }
 
 async fn resolve_modrinth_files(

--- a/crates/bridge/src/safe_path.rs
+++ b/crates/bridge/src/safe_path.rs
@@ -28,7 +28,8 @@ impl SafePath {
     }
 
     pub fn from_std_path(path: &Path) -> Option<SafePath> {
-        Self::from_relative_path(RelativePath::from_path(path).ok()?)
+        let normalized = path.to_str()?.replace('\\', "/");
+        Self::from_relative_path(RelativePath::new(&normalized))
     }
 
     pub fn new(path: &str) -> Option<SafePath> {

--- a/crates/bridge/src/safe_path.rs
+++ b/crates/bridge/src/safe_path.rs
@@ -37,7 +37,8 @@ impl SafePath {
         if trimmed.is_empty() {
             return None;
         }
-        Self::from_relative_path(RelativePath::new(trimmed))
+        let normalized = trimmed.replace('\\', "/");
+        Self::from_relative_path(RelativePath::new(&normalized))
     }
 
     pub fn join(&self, other: &SafePath) -> SafePath {


### PR DESCRIPTION
I found 2 bugs

1) Windows uses `\` as path separator, but the `relative-path` crate only recognizes `/`. So `RelativePath::from_path` compares path components, but doesn't split on `\` and returns error. Because of that only instance root files info_v1.json and stats_v1.json are exported and nothing else

   Fix: replace back slashes with forward slashes before constructing `RelativePath`

2) `ends_with_ignore_ascii_case` can slice a string in the middle of a UTF-8 multi-byte character and this causes panic, e.g.with Cyrillic:
   ```
   [2026-07-07T17:50:12Z ERROR pandora_launcher::panic] Backend panicked at crates\backend\src\export.rs:488:13
   byte index 40 is not a char boundary; it is inside 'р' (bytes 39..41) of `2021-03-15_21-12-44_Моя квартира.zip`
   ```
   
   Fix: convert string to bytes so it doesn't cause panic anymore

Closes #549