### PR TITLE
Add more export options

### DIFF
--- a/crates/backend/src/export.rs
+++ b/crates/backend/src/export.rs
@@ -454,6 +454,7 @@ fn should_skip(rel: &SafePath, rel_to_dot_minecraft: Option<&SafePath>, options:
         "saves" => !options.include_saves,
         "mods" => !options.include_mods,
         "resourcepacks" => !options.include_resourcepacks,
+        "shaderpacks" => !options.include_shaders,
         "config" => !options.include_configs,
         _ => false,
     }
@@ -503,6 +504,10 @@ async fn resolve_modrinth_files(
             continue;
         }
         if is_resourcepack_file(&file.rel) && options.include_resourcepacks {
+            candidates.push(file);
+            continue;
+        }
+        if is_shaderpack_file(&file.rel) && options.include_shaders {
             candidates.push(file);
         }
     }
@@ -639,6 +644,10 @@ async fn resolve_curseforge_files(
             continue;
         }
         if is_resourcepack_file(&file.rel) && options.include_resourcepacks {
+            candidates.push((file.rel.clone(), file.abs.clone(), file.enabled, false));
+            continue;
+        }
+        if is_shaderpack_file(&file.rel) && options.include_shaders {
             candidates.push((file.rel.clone(), file.abs.clone(), file.enabled, false));
         }
     }
@@ -978,6 +987,18 @@ fn is_mod_file(path: &SafePath) -> bool {
 
 fn is_resourcepack_file(path: &SafePath) -> bool {
     if !path.starts_with("resourcepacks") {
+        return false;
+    }
+
+    let Some(filename) = path.file_name() else {
+        return false;
+    };
+
+    filename.ends_with(".zip") || filename.ends_with(".zip.disabled")
+}
+
+fn is_shaderpack_file(path: &SafePath) -> bool {
+    if !path.starts_with("shaderpacks") {
         return false;
     }
 

--- a/crates/backend/src/export.rs
+++ b/crates/backend/src/export.rs
@@ -456,6 +456,7 @@ fn should_skip(rel: &SafePath, rel_to_dot_minecraft: Option<&SafePath>, options:
         "resourcepacks" => !options.include_resourcepacks,
         "shaderpacks" => !options.include_shaders,
         "config" => !options.include_configs,
+        "backups" => !options.include_backups,
         _ => false,
     }
 }

--- a/crates/backend/src/export.rs
+++ b/crates/backend/src/export.rs
@@ -450,7 +450,7 @@ fn should_skip(rel: &SafePath, rel_to_dot_minecraft: Option<&SafePath>, options:
 
     match name {
         "logs" | "crash-reports" => !options.include_logs,
-        ".cache" | "downloads" => !options.include_cache,
+        ".cache" | "downloads" | ".fabric" => !options.include_cache,
         "saves" => !options.include_saves,
         "mods" => !options.include_mods,
         "resourcepacks" => !options.include_resourcepacks,

--- a/crates/backend/src/export.rs
+++ b/crates/backend/src/export.rs
@@ -456,6 +456,7 @@ fn should_skip(rel: &SafePath, rel_to_dot_minecraft: Option<&SafePath>, options:
         "resourcepacks" => !options.include_resourcepacks,
         "shaderpacks" => !options.include_shaders,
         "config" => !options.include_configs,
+        "screenshots" => !options.include_screenshots,
         "backups" => !options.include_backups,
         _ => false,
     }

--- a/crates/bridge/src/message.rs
+++ b/crates/bridge/src/message.rs
@@ -51,6 +51,7 @@ pub struct ExportOptions {
     pub include_saves: bool,
     pub include_mods: bool,
     pub include_resourcepacks: bool,
+    pub include_shaders: bool,
     pub include_configs: bool,
     pub include_logs: bool,
     pub include_cache: bool,

--- a/crates/bridge/src/message.rs
+++ b/crates/bridge/src/message.rs
@@ -53,6 +53,7 @@ pub struct ExportOptions {
     pub include_resourcepacks: bool,
     pub include_shaders: bool,
     pub include_configs: bool,
+    pub include_backups: bool,
     pub include_logs: bool,
     pub include_cache: bool,
     pub include_synced: bool,

--- a/crates/bridge/src/message.rs
+++ b/crates/bridge/src/message.rs
@@ -53,6 +53,7 @@ pub struct ExportOptions {
     pub include_resourcepacks: bool,
     pub include_shaders: bool,
     pub include_configs: bool,
+    pub include_screenshots: bool,
     pub include_backups: bool,
     pub include_logs: bool,
     pub include_cache: bool,

--- a/crates/frontend/src/modals/export_instance.rs
+++ b/crates/frontend/src/modals/export_instance.rs
@@ -29,6 +29,7 @@ struct ExportInstanceModalState {
     include_saves: bool,
     include_mods: bool,
     include_resourcepacks: bool,
+    include_shaders: bool,
     include_configs: bool,
     include_logs: bool,
     include_cache: bool,
@@ -83,6 +84,7 @@ impl ExportInstanceModalState {
             include_saves: true,
             include_mods: true,
             include_resourcepacks: true,
+            include_shaders: true,
             include_configs: true,
             include_logs: false,
             include_cache: false,
@@ -154,6 +156,7 @@ impl ExportInstanceModalState {
             include_saves: self.include_saves,
             include_mods: self.include_mods,
             include_resourcepacks: self.include_resourcepacks,
+            include_shaders: self.include_shaders,
             include_configs: self.include_configs,
             include_logs: self.include_logs,
             include_cache: self.include_cache,
@@ -189,6 +192,10 @@ impl ExportInstanceModalState {
                 .checked(self.include_resourcepacks)
                 .label(t::instance::export::include_resourcepacks())
                 .on_click(cx.listener(|this, value, _, cx| { this.include_resourcepacks = *value; cx.notify(); })))
+            .child(Checkbox::new("include_shaders")
+                .checked(self.include_shaders)
+                .label(t::instance::export::include_shaders())
+                .on_click(cx.listener(|this, value, _, cx| { this.include_shaders = *value; cx.notify(); })))
             .child(Checkbox::new("include_configs")
                 .checked(self.include_configs)
                 .label(t::instance::export::include_configs())

--- a/crates/frontend/src/modals/export_instance.rs
+++ b/crates/frontend/src/modals/export_instance.rs
@@ -31,6 +31,7 @@ struct ExportInstanceModalState {
     include_resourcepacks: bool,
     include_shaders: bool,
     include_configs: bool,
+    include_backups: bool,
     include_logs: bool,
     include_cache: bool,
     include_synced: bool,
@@ -86,6 +87,7 @@ impl ExportInstanceModalState {
             include_resourcepacks: true,
             include_shaders: true,
             include_configs: true,
+            include_backups: true,
             include_logs: false,
             include_cache: false,
             include_synced: false,
@@ -158,6 +160,7 @@ impl ExportInstanceModalState {
             include_resourcepacks: self.include_resourcepacks,
             include_shaders: self.include_shaders,
             include_configs: self.include_configs,
+            include_backups: self.include_backups,
             include_logs: self.include_logs,
             include_cache: self.include_cache,
             include_synced: self.include_synced,
@@ -200,6 +203,10 @@ impl ExportInstanceModalState {
                 .checked(self.include_configs)
                 .label(t::instance::export::include_configs())
                 .on_click(cx.listener(|this, value, _, cx| { this.include_configs = *value; cx.notify(); })))
+            .child(Checkbox::new("include_backups")
+                .checked(self.include_backups)
+                .label(t::instance::export::include_backups())
+                .on_click(cx.listener(|this, value, _, cx| { this.include_backups = *value; cx.notify(); })))
             .child(Checkbox::new("include_logs")
                 .checked(self.include_logs)
                 .label(t::instance::export::include_logs())

--- a/crates/frontend/src/modals/export_instance.rs
+++ b/crates/frontend/src/modals/export_instance.rs
@@ -31,6 +31,7 @@ struct ExportInstanceModalState {
     include_resourcepacks: bool,
     include_shaders: bool,
     include_configs: bool,
+    include_screenshots: bool,
     include_backups: bool,
     include_logs: bool,
     include_cache: bool,
@@ -87,6 +88,7 @@ impl ExportInstanceModalState {
             include_resourcepacks: true,
             include_shaders: true,
             include_configs: true,
+            include_screenshots: true,
             include_backups: true,
             include_logs: false,
             include_cache: false,
@@ -160,6 +162,7 @@ impl ExportInstanceModalState {
             include_resourcepacks: self.include_resourcepacks,
             include_shaders: self.include_shaders,
             include_configs: self.include_configs,
+            include_screenshots: self.include_screenshots,
             include_backups: self.include_backups,
             include_logs: self.include_logs,
             include_cache: self.include_cache,
@@ -203,6 +206,10 @@ impl ExportInstanceModalState {
                 .checked(self.include_configs)
                 .label(t::instance::export::include_configs())
                 .on_click(cx.listener(|this, value, _, cx| { this.include_configs = *value; cx.notify(); })))
+            .child(Checkbox::new("include_screenshots")
+                .checked(self.include_screenshots)
+                .label(t::instance::export::include_screenshots())
+                .on_click(cx.listener(|this, value, _, cx| { this.include_screenshots = *value; cx.notify(); })))
             .child(Checkbox::new("include_backups")
                 .checked(self.include_backups)
                 .label(t::instance::export::include_backups())

--- a/crates/t/locales.toml
+++ b/crates/t/locales.toml
@@ -1078,6 +1078,8 @@ en = "Include resourcepacks"
 de = "Ressourcenpakete (resourcepacks) einbeziehen"
 hu = "forráscsomagok belefoglalása"
 sv = "Inkludera resurspacket"
+[instance.export.include_shaders]
+en = "Include shaders"
 [instance.export.include_configs]
 en = "Include configs"
 de = "Konfigurationsdateien (configs) einbeziehen"

--- a/crates/t/locales.toml
+++ b/crates/t/locales.toml
@@ -1085,6 +1085,8 @@ en = "Include configs"
 de = "Konfigurationsdateien (configs) einbeziehen"
 hu = "Konfigurációk belefoglalása"
 sv = "Inkludera konfigurationsfiler"
+[instance.export.include_backups]
+en = "Include backups"
 [instance.export.include_logs]
 en = "Include logs/crash reports"
 de = "logs/Absturzberichte einbeziehen"

--- a/crates/t/locales.toml
+++ b/crates/t/locales.toml
@@ -1085,6 +1085,8 @@ en = "Include configs"
 de = "Konfigurationsdateien (configs) einbeziehen"
 hu = "Konfigurációk belefoglalása"
 sv = "Inkludera konfigurationsfiler"
+[instance.export.include_screenshots]
+en = "Include screenshots"
 [instance.export.include_backups]
 en = "Include backups"
 [instance.export.include_logs]

--- a/crates/t/src/lib.rs
+++ b/crates/t/src/lib.rs
@@ -1425,6 +1425,7 @@ pub mod instance {
                 "include_mods" => Some(include_mods()),
                 "include_resourcepacks" => Some(include_resourcepacks()),
                 "include_saves" => Some(include_saves()),
+                "include_screenshots" => Some(include_screenshots()),
                 "include_shaders" => Some(include_shaders()),
                 "include_synced" => Some(include_synced()),
                 "modrinth_options" => Some(modrinth_options()),
@@ -1565,6 +1566,11 @@ pub mod instance {
                 2 => "Mentések belefoglalása",
                 3 => "Inkludera världar",
                 _ => "Include saves",
+            }
+        }
+        pub fn include_screenshots() -> &'static str {
+            match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
+                _ => "Include screenshots",
             }
         }
         pub fn include_shaders() -> &'static str {

--- a/crates/t/src/lib.rs
+++ b/crates/t/src/lib.rs
@@ -1418,6 +1418,7 @@ pub mod instance {
                 "author" => Some(author()),
                 "curseforge_options" => Some(curseforge_options()),
                 "error" => Some(error()),
+                "include_backups" => Some(include_backups()),
                 "include_cache" => Some(include_cache()),
                 "include_configs" => Some(include_configs()),
                 "include_logs" => Some(include_logs()),
@@ -1511,6 +1512,11 @@ pub mod instance {
                     3 => "Instans Zip-fil",
                     _ => "Instance Zip",
                 }
+            }
+        }
+        pub fn include_backups() -> &'static str {
+            match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
+                _ => "Include backups",
             }
         }
         pub fn include_cache() -> &'static str {

--- a/crates/t/src/lib.rs
+++ b/crates/t/src/lib.rs
@@ -1424,6 +1424,7 @@ pub mod instance {
                 "include_mods" => Some(include_mods()),
                 "include_resourcepacks" => Some(include_resourcepacks()),
                 "include_saves" => Some(include_saves()),
+                "include_shaders" => Some(include_shaders()),
                 "include_synced" => Some(include_synced()),
                 "modrinth_options" => Some(modrinth_options()),
                 "name" => Some(name()),
@@ -1558,6 +1559,11 @@ pub mod instance {
                 2 => "Mentések belefoglalása",
                 3 => "Inkludera världar",
                 _ => "Include saves",
+            }
+        }
+        pub fn include_shaders() -> &'static str {
+            match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
+                _ => "Include shaders",
             }
         }
         pub fn include_synced() -> &'static str {


### PR DESCRIPTION
Folders like backups and screenshots can be very big and usually I don't want to include them in modpack. This PR adds a possibility to exclude them. Fabric cache is also excluded if cache is not selected. Shaders are now handled similar to mods and resourcepacks, and are hashed by modrinth/curseforge. 

<img width="548" height="526" src="https://github.com/user-attachments/assets/339599a9-2940-495f-8781-0e12b6cd3cd2" />