### PR TITLE
Translated new lines, changed small things (Hungarian)

### DIFF
--- a/crates/t/locales.toml
+++ b/crates/t/locales.toml
@@ -957,7 +957,7 @@ sv = "Namn"
 [instance.name_placeholder]
 en = "<instance name>"
 de = "<Instanz Name>"
-hu = "<példány neve"
+hu = "<példány neve>"
 sv = "<instansens namn>"
 [instance.version]
 en = "Version"
@@ -1017,7 +1017,7 @@ sv = "Ogiltigt namn"
 [instance.export.action]
 en = "Export"
 de = "Exportieren"
-hu = "Export"
+hu = "Exportálás"
 sv = "Exportera"
 [instance.export.title]
 en = "Export Instance"
@@ -1086,6 +1086,7 @@ hu = "forráscsomagok belefoglalása"
 sv = "Inkludera resurspacket"
 [instance.export.include_shaders]
 en = "Include shaders"
+hu = "Shaderek belefoglalása"
 [instance.export.include_configs]
 en = "Include configs"
 de = "Konfigurationsdateien (configs) einbeziehen"
@@ -1093,8 +1094,10 @@ hu = "Konfigurációk belefoglalása"
 sv = "Inkludera konfigurationsfiler"
 [instance.export.include_screenshots]
 en = "Include screenshots"
+hu = "Képernyőképek belefoglalása"
 [instance.export.include_backups]
 en = "Include backups"
+hu = "Biztonsági mentések belefoglalása"
 [instance.export.include_logs]
 en = "Include logs/crash reports"
 de = "logs/Absturzberichte einbeziehen"
@@ -1473,7 +1476,7 @@ sv = "Kategorier"
 [instance.content.sort]
 en = "Sort by"
 de = "Sortieren nach"
-hu = "Rendszerezés"
+hu = "Sorrend"
 sv = "Sortera efter"
 [instance.content.downloads.b]
 # Billion
@@ -1741,7 +1744,7 @@ sv = "Installera manuellt - kan inte automatiskt uppdatera"
 [instance.sync.label]
 en = "Syncing"
 de = "Synchronisierung"
-hu = "Stinkronizál"
+hu = "Szinkronizálás"
 sv = "Synkar"
 [instance.sync.description]
 en = "These options allow for syncing various files/folders across instances"
@@ -1915,8 +1918,10 @@ hu = "Hálózat"
 sv = "Nätvärk"
 [settings.language.title]
 en = "Language"
+hu = "Nyelv"
 [settings.language.system]
 en = "System language"
+hu = "Rendszer nyelv"
 [settings.theme.title]
 en = "Theme"
 de = "Farbschema"
@@ -2110,8 +2115,10 @@ hu = "Mappa megnyitása"
 sv = "Öppna folder"
 [skins.sort.oldest_first]
 en = "Oldest first"
+hu = "Régi először"
 [skins.sort.newest_first]
 en = "Newest first"
+hu = "Új először"
 [skins.switch_view.texture]
 en = "Switch to texture"
 de = "Wechsle zu Textur"


### PR DESCRIPTION
# Some hardcoded text i found:

## Skin menu
<img width="768" height="661" alt="Képernyőkép 2026-07-10 180033" src="https://github.com/user-attachments/assets/107ca88a-238b-412a-9868-57b916cdd387" />

## Import menu
<img width="1649" height="471" alt="Képernyőkép 2026-07-10 180112" src="https://github.com/user-attachments/assets/d22aac6b-c43b-49a1-9c54-8056db4a9795" />

## Viewing an instance
<img width="637" height="264" alt="Képernyőkép 2026-07-10 180222" src="https://github.com/user-attachments/assets/d24729c5-c388-4f65-8664-68c34ad21b4d" />

## Mod search bar
<img width="635" height="335" alt="Képernyőkép 2026-07-10 181810" src="https://github.com/user-attachments/assets/54c595d9-266c-4849-85fb-0ac0139e3580" />

## Account override in instance
<img width="814" height="658" alt="Képernyőkép 2026-07-10 182417" src="https://github.com/user-attachments/assets/0ae9f192-1b06-4ddb-b412-3264f75bfe3d" />

## Sandbox description
<img width="819" height="689" alt="Képernyőkép 2026-07-10 182820" src="https://github.com/user-attachments/assets/f5f4a3f3-9dde-4a19-948a-7ad1824aee8b" />

## Proxy settings
<img width="405" height="355" alt="Képernyőkép 2026-07-10 183957" src="https://github.com/user-attachments/assets/72456be9-fda9-4937-aa04-cee3f2fdffdb" />