### PR TITLE
Fall back to English instead of panicking when unsupported language is detected

### DIFF
--- a/crates/t/build.rs
+++ b/crates/t/build.rs
@@ -76,7 +76,7 @@ fn inner(dir: &Path) -> Result<(), Box<dyn Error>> {
         content.push_str(&format!("{}", lang_id));
         content.push_str(",\n");
     }
-    content.push_str("\t\t_ => panic!(\"Unknown language: {code}\"),\n");
+    content.push_str("\t\t_ => 0,\n");
     content.push_str("\t};\n");
     content.push_str("\tLANG.store(id, std::sync::atomic::Ordering::Relaxed);\n");
     content.push_str("}\n\n");

--- a/crates/t/src/lib.rs
+++ b/crates/t/src/lib.rs
@@ -43,7 +43,7 @@ pub fn set_lang(lang: &Language) {
 		"de" => 1,
 		"hu" => 2,
 		"sv" => 3,
-		_ => panic!("Unknown language: {code}"),
+		_ => 0,
 	};
 	LANG.store(id, std::sync::atomic::Ordering::Relaxed);
 }


### PR DESCRIPTION
Closes #579 

I noticed that when I was trying to launch the launcher, my system language (Polish, which is not supported) caused the panic immediately

I changed it to fall back to English instead of panicking