### PR TITLE
ui: fix Sync page open folder button overflow

### DIFF
--- a/crates/frontend/src/pages/syncing_page.rs
+++ b/crates/frontend/src/pages/syncing_page.rs
@@ -163,9 +163,11 @@ impl Render for SyncingPage {
         let info = cx.theme().blue;
         let content = v_flex().size_full().p_3().gap_3()
             .child(t::instance::sync::description())
-            .child(Button::new("open").info().icon(PandoraIcon::FolderOpen).label(t::instance::sync::open_folder()).on_click(move |_, window, cx| {
-                crate::open_folder(&sync_folder, window, cx);
-            }).w_72())
+            .child(h_flex().w_full().child(
+                Button::new("open").info().icon(PandoraIcon::FolderOpen).label(t::instance::sync::open_folder()).on_click(move |_, window, cx| {
+                    crate::open_folder(&sync_folder, window, cx);
+                })).min_w_72()
+            )
             .child(div().border_b_1().border_color(cx.theme().border).text_lg().child(t::instance::sync::files()))
             .child(self.create_entry(sync_state, "options.txt".into(), true,  t::instance::sync::targets::options().into(), warning, info, cx))
             .child(self.create_entry(sync_state, "servers.dat".into(), true, t::instance::sync::targets::servers().into(), warning, info, cx))


### PR DESCRIPTION
# How

Fix Sync page open folder button overflow for languages with longer label.

# Preview

### Before

<img width="748" height="468" alt="Screenshot 2026-07-11 at 17 13 13" src="https://github.com/user-attachments/assets/162d27bf-d874-4267-a5cf-e4b5229ccee8" />

### After

<img width="748" height="468" alt="Screenshot 2026-07-11 at 17 11 27" src="https://github.com/user-attachments/assets/d624f5d3-62f9-4fbf-a9dc-a32947731ff9" />
