### PR TITLE
Improve unique numbered filenames generation

### DIFF
--- a/crates/backend/src/backend_handler.rs
+++ b/crates/backend/src/backend_handler.rs
@@ -13,7 +13,7 @@ use ustr::Ustr;
 use uuid::Uuid;
 
 use crate::{
-    BackendState, CachedMinecraftProfile, FolderChanges, LoginError, account::BackendAccount, arcfactory::ArcStrFactory, instance::Instance, launch::{ArgumentExpansionKey, LaunchError}, log_reader, metadata::{items::{AssetsIndexMetadataItem, CurseforgeGetModFilesMetadataItem, CurseforgeSearchMetadataItem, FabricLoaderManifestMetadataItem, ForgeInstallerMavenMetadataItem, MinecraftVersionManifestMetadataItem, MinecraftVersionMetadataItem, ModrinthProjectMetadataItem, ModrinthProjectVersionsMetadataItem, ModrinthSearchMetadataItem, ModrinthV3VersionUpdateMetadataItem, ModrinthVersionUpdateMetadataItem, MojangJavaRuntimeComponentMetadataItem, MojangJavaRuntimesMetadataItem, NeoforgeInstallerMavenMetadataItem, VersionUpdateParameters, VersionV3LoaderFields, VersionV3UpdateParameters}, manager::MetaLoadError}, mod_metadata::{ContentUpdateAction, ContentUpdateKey}, skin_manager::SkinManager
+    BackendState, CachedMinecraftProfile, FolderChanges, LoginError, account::BackendAccount, arcfactory::ArcStrFactory, instance::Instance, launch::{ArgumentExpansionKey, LaunchError}, log_reader, metadata::{items::{AssetsIndexMetadataItem, CurseforgeGetModFilesMetadataItem, CurseforgeSearchMetadataItem, FabricLoaderManifestMetadataItem, ForgeInstallerMavenMetadataItem, MinecraftVersionManifestMetadataItem, MinecraftVersionMetadataItem, ModrinthProjectMetadataItem, ModrinthProjectVersionsMetadataItem, ModrinthSearchMetadataItem, ModrinthV3VersionUpdateMetadataItem, ModrinthVersionUpdateMetadataItem, MojangJavaRuntimeComponentMetadataItem, MojangJavaRuntimesMetadataItem, NeoforgeInstallerMavenMetadataItem, VersionUpdateParameters, VersionV3LoaderFields, VersionV3UpdateParameters}, manager::MetaLoadError}, mod_metadata::{ContentUpdateAction, ContentUpdateKey}, skin_manager::SkinManager, unique_name
 };
 
 impl BackendState {
@@ -1781,19 +1781,8 @@ impl BackendState {
                 }
 
                 let filename = sanitize_filename::sanitize_with_options(filename, sanitize_filename::Options { windows: true, ..Default::default() });
-
-                let mut path = self.directories.skin_library_dir.join(&filename);
-
-                if path.exists() {
-                    for i in 1..32 {
-                        let new_filename = format!("{filename} ({i})");
-                        let new_path = self.directories.skin_library_dir.join(&new_filename);
-                        if !new_path.exists() {
-                            path = new_path;
-                            break;
-                        }
-                    }
-                }
+                let filename = unique_name(&self.directories.skin_library_dir, &filename, false);
+                let path = self.directories.skin_library_dir.join(&*filename);
 
                 if let Err(err) = crate::write_safe(&path, &bytes) {
                     log::error!("Error while saving skin: {:?}", err);
@@ -1927,18 +1916,8 @@ impl BackendState {
                 }
 
                 let filename = sanitize_filename::sanitize_with_options(filename, sanitize_filename::Options { windows: true, ..Default::default() });
-
-                let mut path = self.directories.skin_library_dir.join(&filename);
-                if path.exists() {
-                    for i in 1..32 {
-                        let new_filename = format!("{filename} ({i})");
-                        let new_path = self.directories.skin_library_dir.join(&new_filename);
-                        if !new_path.exists() {
-                            path = new_path;
-                            break;
-                        }
-                    }
-                }
+                let filename = unique_name(&self.directories.skin_library_dir, &filename, false);
+                let path = self.directories.skin_library_dir.join(&*filename);
 
                 if let Err(err) = crate::write_safe(&path, &bytes) {
                     log::error!("CopyPlayerSkin: failed to save skin: {:?}", err);

--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(unused_must_use)]
 
 mod backend;
-use std::{ffi::{OsStr, OsString}, io::{Error, ErrorKind, Write}, path::{Path, PathBuf}, sync::Arc};
+use std::{borrow::Cow, ffi::{OsStr, OsString}, io::{Error, ErrorKind, Write}, path::{Path, PathBuf}, sync::Arc};
 
 pub use backend::*;
 use bridge::instance::InstanceContentSummary;
@@ -47,6 +47,33 @@ pub(crate) fn is_single_component_path(path: &Path) -> bool {
     }
 
     components.count() == 1
+}
+
+pub fn unique_name<'a>(parent: &Path, original_name: &'a str, is_dir: bool) -> Cow<'a, str> {
+    let candidate = Path::new(original_name);
+    if !parent.join(candidate).exists() {
+        return Cow::Borrowed(original_name);
+    }
+
+    if is_dir {
+        for i in 1..=i32::MAX {
+            let numbered = format!("{original_name} ({i})");
+            if !parent.join(&numbered).exists() {
+                return Cow::Owned(numbered);
+            }
+        }
+    } else {
+        let stem = candidate.file_stem().unwrap_or_default().to_string_lossy();
+        let ext = candidate.extension().map(|e| format!(".{}", e.to_string_lossy())).unwrap_or_default();
+        for i in 1..=i32::MAX {
+            let numbered = format!("{stem} ({i}){ext}");
+            if !parent.join(&numbered).exists() {
+                return Cow::Owned(numbered);
+            }
+        }
+    }
+
+    panic!("Unable to find a unique name for '{original_name}' after {} retries", i32::MAX)
 }
 
 pub(crate) fn check_sha1_hash(path: &Path, expected_hash: [u8; 20]) -> std::io::Result<bool> {

--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -9,6 +9,7 @@ use rand::RngCore;
 use rustc_hash::FxHashSet;
 use serde::Deserialize;
 use sha1::{Digest, Sha1};
+use uuid::Uuid;
 
 mod backend_filesystem;
 mod backend_handler;
@@ -50,30 +51,28 @@ pub(crate) fn is_single_component_path(path: &Path) -> bool {
 }
 
 pub fn unique_name<'a>(parent: &Path, original_name: &'a str, is_dir: bool) -> Cow<'a, str> {
-    let candidate = Path::new(original_name);
-    if !parent.join(candidate).exists() {
+    if !parent.join(original_name).exists() {
         return Cow::Borrowed(original_name);
     }
 
-    if is_dir {
-        for i in 1..=i32::MAX {
-            let numbered = format!("{original_name} ({i})");
-            if !parent.join(&numbered).exists() {
-                return Cow::Owned(numbered);
-            }
-        }
+    let candidate = Path::new(original_name);
+    let (stem, ext) = if is_dir {
+        (Cow::Borrowed(original_name), String::new())
     } else {
         let stem = candidate.file_stem().unwrap_or_default().to_string_lossy();
         let ext = candidate.extension().map(|e| format!(".{}", e.to_string_lossy())).unwrap_or_default();
-        for i in 1..=i32::MAX {
-            let numbered = format!("{stem} ({i}){ext}");
-            if !parent.join(&numbered).exists() {
-                return Cow::Owned(numbered);
-            }
+        (stem, ext)
+    };
+
+    const MAX_RETRIES: u32 = 100;
+    for i in 1..MAX_RETRIES {
+        let numbered = format!("{stem} ({i}){ext}");
+        if !parent.join(&numbered).exists() {
+            return Cow::Owned(numbered);
         }
     }
 
-    panic!("Unable to find a unique name for '{original_name}' after {} retries", i32::MAX)
+    Cow::Owned(format!("{stem} ({}){ext}", Uuid::new_v4()))
 }
 
 pub(crate) fn check_sha1_hash(path: &Path, expected_hash: [u8; 20]) -> std::io::Result<bool> {


### PR DESCRIPTION
This logic for adding skins was repeated 2 times:
```rust
if path.exists() {
    for i in 1..32 {
        let new_filename = format!("{filename} ({i})");
        let new_path = self.directories.skin_library_dir.join(&new_filename);
        if !new_path.exists() {
            path = new_path;
            break;
        }
    }
}
```

- I extracted the logic into `lib.rs` so it can be reused across the backend
- If a file has extension, number will be placed before it (`skin (1).png`, not `skin.png (1)`)
- Does not overwrite old file if all numbered names within an attempted range are taken, instead appends a uuid
- Increased number of attempts from 32 to 100 (don't think someone will ever hit that limit but why not)