### PR TITLE
Feat: Add optional in-app Game Output tab for instances

### DIFF
--- a/crates/backend/src/backend_handler.rs
+++ b/crates/backend/src/backend_handler.rs
@@ -145,6 +145,13 @@ impl BackendState {
                     });
                 }
             },
+            MessageToBackend::SetInstanceTerminalInTab { id, value } => {
+                if let Some(instance) = self.instance_state.write().instances.get_mut(id) {
+                    instance.configuration.modify(|configuration| {
+                        configuration.terminal_in_tab = value;
+                    });
+                }
+            },
             MessageToBackend::SetInstanceMemory { id, memory } => {
                 if let Some(instance) = self.instance_state.write().instances.get_mut(id) {
                     instance.configuration.modify(|configuration| {
@@ -1411,6 +1418,11 @@ impl BackendState {
                     config.dont_open_game_output_when_launching = !value;
                 });
             },
+            MessageToBackend::SetTerminalInTab { value } => {
+                self.config.write().modify(|config| {
+                    config.terminal_in_tab = value;
+                });
+            },
             MessageToBackend::SetProxyConfiguration { config, password } => {
                 self.config.write().modify(|backend_config| {
                     backend_config.proxy = config;
@@ -2011,6 +2023,7 @@ impl BackendState {
         }
 
         let game_output = !self.config.write().get().dont_open_game_output_when_launching;
+        let effective_terminal_in_tab = configuration.terminal_in_tab_effective(self.config.write().get().terminal_in_tab);
 
         let launch_tracker = ProgressTracker::new(Arc::from("Launching"), self.send.clone());
         modal_action.trackers.push(launch_tracker.clone());
@@ -2026,7 +2039,12 @@ impl BackendState {
             Ok(mut child) => {
                 if game_output {
                     if let Some(stdout) = child.stdout.take() {
-                        log_reader::start_game_output(stdout, child.stderr.take(), self.send.clone());
+                        let receiver = log_reader::start_game_output(stdout, child.stderr.take());
+                        if effective_terminal_in_tab {
+                            self.send.send(MessageToFrontend::AttachGameOutput { id, receiver });
+                        } else {
+                            self.send.send(MessageToFrontend::CreateGameOutputWindow { receiver });
+                        }
                     }
                 }
 

--- a/crates/backend/src/log_reader.rs
+++ b/crates/backend/src/log_reader.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, io::{BufRead, BufReader, PipeReader}, sync::Arc};
 
 use bridge::{
-    game_output::GameOutputLogLevel, handle::FrontendHandle, message::{GameOutputMsg, MessageToFrontend},
+    game_output::GameOutputLogLevel, message::GameOutputMsg,
 };
 use chrono::Utc;
 use memchr::memchr;
@@ -33,9 +33,8 @@ pub fn replace(string: &str) -> Cow<'_, str> {
     replaced
 }
 
-pub fn start_game_output(stdout: PipeReader, stderr: Option<PipeReader>, frontend: FrontendHandle) {
+pub fn start_game_output(stdout: PipeReader, stderr: Option<PipeReader>) -> tokio::sync::mpsc::UnboundedReceiver<GameOutputMsg> {
     let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
-    frontend.send(MessageToFrontend::CreateGameOutputWindow { receiver });
 
     if let Some(stderr) = stderr {
         let sender = sender.clone();
@@ -129,6 +128,8 @@ pub fn start_game_output(stdout: PipeReader, stderr: Option<PipeReader>, fronten
             });
         }
     });
+
+    receiver
 }
 
 #[derive(Error, Debug)]

--- a/crates/bridge/src/message.rs
+++ b/crates/bridge/src/message.rs
@@ -111,6 +111,10 @@ pub enum MessageToBackend {
         id: InstanceID,
         sandbox: bool,
     },
+    SetInstanceTerminalInTab {
+        id: InstanceID,
+        value: Option<bool>,
+    },
     SetInstanceMemory {
         id: InstanceID,
         memory: InstanceMemoryConfiguration,
@@ -259,6 +263,9 @@ pub enum MessageToBackend {
     SetOpenGameOutputAfterLaunching {
         value: bool,
     },
+    SetTerminalInTab {
+        value: bool,
+    },
     SetProxyConfiguration {
         config: ProxyConfig,
         password: Option<String>,
@@ -360,6 +367,10 @@ pub enum MessageToFrontend {
     },
     CreateGameOutputWindow {
         receiver: tokio::sync::mpsc::UnboundedReceiver<GameOutputMsg>
+    },
+    AttachGameOutput {
+        id: InstanceID,
+        receiver: tokio::sync::mpsc::UnboundedReceiver<GameOutputMsg>,
     },
     AddNotification {
         notification_type: BridgeNotificationType,

--- a/crates/frontend/src/entity/instance.rs
+++ b/crates/frontend/src/entity/instance.rs
@@ -8,6 +8,8 @@ use gpui_component::select::SelectItem;
 use indexmap::IndexMap;
 use schema::{instance::InstanceConfiguration, unique_bytes::UniqueBytes};
 
+use crate::game_output::GameOutput;
+
 pub struct InstanceEntries {
     pub entries: IndexMap<InstanceID, Entity<InstanceEntry>>,
 }
@@ -44,6 +46,7 @@ impl InstanceEntries {
                 servers: cx.new(|_| [].into()),
                 content_states,
                 content: enum_map::EnumMap::from_fn(|_| cx.new(|_| [].into())),
+                terminal_output: None,
             };
             instance.title = instance.create_title();
 
@@ -209,6 +212,7 @@ pub struct InstanceEntry {
     pub servers: Entity<Arc<[InstanceServerSummary]>>,
     pub content_states: ContentStates,
     pub content: enum_map::EnumMap<ContentFolder, Entity<Arc<[InstanceContentSummary]>>>,
+    pub terminal_output: Option<Entity<GameOutput>>,
 }
 
 #[derive(Clone)]

--- a/crates/frontend/src/game_output/mod.rs
+++ b/crates/frontend/src/game_output/mod.rs
@@ -847,6 +847,7 @@ pub struct GameOutputRoot {
     _search_task: Task<()>,
     _search_input_subscription: Subscription,
     focus_handle: FocusHandle,
+    close_window_on_action: bool,
 }
 
 #[derive(Clone)]
@@ -956,6 +957,23 @@ impl GameOutputRoot {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
+        Self::new_impl(game_output, true, window, cx)
+    }
+
+    pub fn new_in_tab(
+        game_output: Entity<GameOutput>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        Self::new_impl(game_output, false, window, cx)
+    }
+
+    fn new_impl(
+        game_output: Entity<GameOutput>,
+        close_window_on_action: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
         let scroll_state = Rc::clone(&game_output.read(cx).scroll_state);
 
         let search_state = cx.new(|cx| InputState::new(window, cx).placeholder(t::common::search()).clean_on_escape());
@@ -972,6 +990,7 @@ impl GameOutputRoot {
             _search_task: Task::ready(()),
             _search_input_subscription,
             focus_handle,
+            close_window_on_action,
         }
     }
 
@@ -1124,8 +1143,10 @@ impl Render for GameOutputRoot {
                 }
             }))
             .track_focus(&self.focus_handle)
-            .on_action(|_: &CloseWindow, window, _| {
-                window.remove_window();
+            .when(self.close_window_on_action, |this| {
+                this.on_action(|_: &CloseWindow, window, _| {
+                    window.remove_window();
+                })
             })
     }
 }

--- a/crates/frontend/src/interface_config.rs
+++ b/crates/frontend/src/interface_config.rs
@@ -57,6 +57,8 @@ pub struct InterfaceConfig {
     #[serde(default, deserialize_with = "schema::try_deserialize")]
     pub hide_main_window_on_launch: bool,
     #[serde(default, deserialize_with = "schema::try_deserialize")]
+    pub terminal_in_tab: bool,
+    #[serde(default, deserialize_with = "schema::try_deserialize")]
     pub quit_on_main_closed: bool,
     #[serde(default, deserialize_with = "schema::try_deserialize")]
     pub use_os_titlebar: bool,
@@ -159,6 +161,7 @@ impl Default for InterfaceConfig {
             modrinth_page_project_type: default_modrinth_project_type(),
             curseforge_page_class_id: default_curseforge_class_id(),
             hide_main_window_on_launch: false,
+            terminal_in_tab: false,
             quit_on_main_closed: false,
             use_os_titlebar: false,
             hide_server_addresses: false,

--- a/crates/frontend/src/lib.rs
+++ b/crates/frontend/src/lib.rs
@@ -93,6 +93,12 @@ pub fn start(
 
         t::set_lang(&InterfaceConfig::get(cx).language);
 
+        // Keep the backend's routing copy of the global terminal-in-tab setting in sync with the
+        // frontend-owned value, so shortcut/CLI launches route correctly.
+        backend_handle.send(bridge::message::MessageToBackend::SetTerminalInTab {
+            value: InterfaceConfig::get(cx).terminal_in_tab,
+        });
+
         gpui_component::Theme::change(gpui_component::ThemeMode::Dark, None, cx);
 
         let theme_folder = launcher_dir.join("themes");

--- a/crates/frontend/src/modals/settings.rs
+++ b/crates/frontend/src/modals/settings.rs
@@ -393,6 +393,18 @@ impl Settings {
                                     settings.update_backend_configuration(window, cx);
                                 }
                             })))
+                        .child(Checkbox::new("terminal-in-tab")
+                            .label(t::settings::windows::terminal_in_tab())
+                            .checked(interface_config.terminal_in_tab)
+                            .on_click(cx.listener({
+                                let backend_handle = self.backend_handle.clone();
+                                move |_settings, value, _window, cx| {
+                                    InterfaceConfig::get_mut(cx).terminal_in_tab = *value;
+                                    backend_handle.send(MessageToBackend::SetTerminalInTab {
+                                        value: *value
+                                    });
+                                }
+                            })))
                         .child(Checkbox::new("quit-on-main-close")
                             .label(t::settings::windows::close_all_when_main_closed())
                             .checked(interface_config.quit_on_main_closed)

--- a/crates/frontend/src/pages/instance/instance_page.rs
+++ b/crates/frontend/src/pages/instance/instance_page.rs
@@ -10,7 +10,7 @@ use gpui_component::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    entity::{DataEntities, instance::InstanceEntry}, icon::PandoraIcon, interface_config::InterfaceConfig, pages::{instance::{content_subpage::InstanceContentSubpage, logs_subpage::InstanceLogsSubpage, quickplay_subpage::InstanceQuickplaySubpage, settings_subpage::InstanceSettingsSubpage}, page::Page}, root,
+    entity::{DataEntities, instance::InstanceEntry}, icon::PandoraIcon, interface_config::InterfaceConfig, pages::{instance::{content_subpage::InstanceContentSubpage, logs_subpage::InstanceLogsSubpage, quickplay_subpage::InstanceQuickplaySubpage, settings_subpage::InstanceSettingsSubpage, terminal_subpage::InstanceTerminalSubpage}, page::Page}, root,
 };
 
 use super::content_subpage::ContentType;
@@ -25,6 +25,8 @@ pub struct InstancePage {
 impl InstancePage {
     pub fn new(instance_id: InstanceID, data: &DataEntities, window: &mut Window, cx: &mut Context<Self>) -> Self {
         let instance = data.instances.read(cx).entries.get(&instance_id).unwrap().clone();
+
+        cx.observe(&instance, |_, _, cx| cx.notify()).detach();
 
         let instance_subpage = InterfaceConfig::get(cx).instance_subpage;
         let subpage = instance_subpage.create(&instance, data, data.backend_handle.clone(), window, cx);
@@ -144,62 +146,59 @@ impl Page for InstancePage {
 
 impl Render for InstancePage {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let instance_subpage = InterfaceConfig::get(cx).instance_subpage;
+        let mut instance_subpage = InterfaceConfig::get(cx).instance_subpage;
+
+        let global_terminal_in_tab = InterfaceConfig::get(cx).terminal_in_tab;
+        let effective_terminal_in_tab = self.instance.read(cx).configuration.terminal_in_tab.unwrap_or(global_terminal_in_tab);
+
+        // The Terminal tab is shown whenever the instance's effective mode is "tab" (live, even
+        // before the first launch). If a "Terminal" selection is active but the effective mode is no
+        // longer tab, fall back to Settings.
+        if instance_subpage == InstanceSubpageType::Terminal && !effective_terminal_in_tab {
+            instance_subpage = InstanceSubpageType::Settings;
+        }
+
         if instance_subpage != self.subpage.page_type() {
             self.subpage = instance_subpage.create(&self.instance, &self.data, self.backend_handle.clone(), window, cx);
         }
 
         let show_shader_tab = self.instance.read(cx).configuration.show_shader_tab || matches!(self.subpage, InstanceSubpage::Shaders(_));
+        let show_terminal_tab = effective_terminal_in_tab;
 
-        let selected_index = match &self.subpage {
-            InstanceSubpage::Quickplay(_) => 0,
-            InstanceSubpage::Logs(_) => 1,
-            InstanceSubpage::Mods(_) => 2,
-            InstanceSubpage::ResourcePacks(_) => 3,
-            InstanceSubpage::Shaders(_) => 4,
-            InstanceSubpage::Settings(_) => if show_shader_tab { 5 } else { 4 },
-        };
+        let mut tabs: Vec<(InstanceSubpageType, SharedString)> = vec![
+            (InstanceSubpageType::Quickplay, t::instance::quickplay().into()),
+            (InstanceSubpageType::Logs, t::instance::logs::title().into()),
+            (InstanceSubpageType::Mods, t::instance::content::mods().into()),
+            (InstanceSubpageType::ResourcePacks, t::instance::content::resourcepacks().into()),
+        ];
+        if show_shader_tab {
+            tabs.push((InstanceSubpageType::Shaders, t::instance::content::shaders().into()));
+        }
+        tabs.push((InstanceSubpageType::Settings, t::settings::title().into()));
+        if show_terminal_tab {
+            tabs.push((InstanceSubpageType::Terminal, t::instance::terminal::title().into()));
+        }
+
+        let current_type = self.subpage.page_type();
+        let selected_index = tabs.iter().position(|(ty, _)| *ty == current_type).unwrap_or(0);
+        let tab_types: Vec<InstanceSubpageType> = tabs.iter().map(|(ty, _)| *ty).collect();
+
+        let mut tab_bar = TabBar::new("bar")
+            .prefix(div().w_4())
+            .selected_index(selected_index)
+            .underline();
+        for (_, label) in &tabs {
+            tab_bar = tab_bar.child(Tab::new().label(label.clone()));
+        }
+        let tab_bar = tab_bar.on_click(cx.listener(move |_, index: &usize, _, cx| {
+            if let Some(page_type) = tab_types.get(*index) {
+                InterfaceConfig::get_mut(cx).instance_subpage = *page_type;
+            }
+        }));
 
         v_flex()
             .size_full()
-            .child(
-                TabBar::new("bar")
-                    .prefix(div().w_4())
-                    .selected_index(selected_index)
-                    .underline()
-                    .child(Tab::new().label(t::instance::quickplay()))
-                    .child(Tab::new().label(t::instance::logs::title()))
-                    .child(Tab::new().label(t::instance::content::mods()))
-                    .child(Tab::new().label(t::instance::content::resourcepacks()))
-                    .when(show_shader_tab, |this| {
-                        this.child(Tab::new().label(t::instance::content::shaders()))
-                    })
-                    .child(Tab::new().label(t::settings::title()))
-                    .on_click(cx.listener(move |_, index, _, cx| {
-                        let page_type = match *index {
-                            0 => InstanceSubpageType::Quickplay,
-                            1 => InstanceSubpageType::Logs,
-                            2 => InstanceSubpageType::Mods,
-                            3 => InstanceSubpageType::ResourcePacks,
-                            4 => if show_shader_tab {
-                                InstanceSubpageType::Shaders
-                            } else {
-                                InstanceSubpageType::Settings
-                            },
-                            5 => {
-                                if show_shader_tab {
-                                    InstanceSubpageType::Settings
-                                } else {
-                                    return;
-                                }
-                            },
-                            _ => {
-                                return;
-                            },
-                        };
-                        InterfaceConfig::get_mut(cx).instance_subpage = page_type;
-                    })),
-            )
+            .child(tab_bar)
             .child(self.subpage.clone().into_any_element())
     }
 }
@@ -214,6 +213,7 @@ pub enum InstanceSubpageType {
     ResourcePacks,
     Shaders,
     Settings,
+    Terminal,
 }
 
 impl InstanceSubpageType {
@@ -244,6 +244,9 @@ impl InstanceSubpageType {
             InstanceSubpageType::Settings => InstanceSubpage::Settings(cx.new(|cx| {
                 InstanceSettingsSubpage::new(instance, data, backend_handle, window, cx)
             })),
+            InstanceSubpageType::Terminal => InstanceSubpage::Terminal(cx.new(|cx| {
+                InstanceTerminalSubpage::new(instance, window, cx)
+            })),
         }
     }
 }
@@ -256,6 +259,7 @@ pub enum InstanceSubpage {
     ResourcePacks(Entity<InstanceContentSubpage>),
     Shaders(Entity<InstanceContentSubpage>),
     Settings(Entity<InstanceSettingsSubpage>),
+    Terminal(Entity<InstanceTerminalSubpage>),
 }
 
 impl InstanceSubpage {
@@ -267,6 +271,7 @@ impl InstanceSubpage {
             InstanceSubpage::ResourcePacks(_) => InstanceSubpageType::ResourcePacks,
             InstanceSubpage::Shaders(_) => InstanceSubpageType::Shaders,
             InstanceSubpage::Settings(_) => InstanceSubpageType::Settings,
+            InstanceSubpage::Terminal(_) => InstanceSubpageType::Terminal,
         }
     }
 
@@ -278,6 +283,7 @@ impl InstanceSubpage {
             Self::ResourcePacks(entity) => entity.into_any_element(),
             Self::Shaders(entity) => entity.into_any_element(),
             Self::Settings(entity) => entity.into_any_element(),
+            Self::Terminal(entity) => entity.into_any_element(),
         }
     }
 }

--- a/crates/frontend/src/pages/instance/mod.rs
+++ b/crates/frontend/src/pages/instance/mod.rs
@@ -3,3 +3,4 @@ pub mod instance_page;
 pub mod logs_subpage;
 pub mod quickplay_subpage;
 pub mod settings_subpage;
+pub mod terminal_subpage;

--- a/crates/frontend/src/pages/instance/settings_subpage.rs
+++ b/crates/frontend/src/pages/instance/settings_subpage.rs
@@ -40,6 +40,7 @@ pub struct InstanceSettingsSubpage {
     disable_file_syncing: bool,
     sandbox_available: bool,
     sandbox: bool,
+    terminal_mode_state: Entity<SelectState<NamedDropdown<Option<bool>>>>,
 
     memory_override_enabled: bool,
     memory_min_input_state: Entity<InputState>,
@@ -94,6 +95,7 @@ impl InstanceSettingsSubpage {
         let account = entry.configuration.preferred_account;
         let disable_file_syncing = entry.configuration.disable_file_syncing;
         let sandbox = entry.configuration.sandbox;
+        let terminal_in_tab_override = entry.configuration.terminal_in_tab;
 
         let sandbox_available = if cfg!(target_os = "linux") {
             command::is_command_available("bwrap") && command::is_command_available("xdg-dbus-proxy")
@@ -168,6 +170,21 @@ impl InstanceSettingsSubpage {
         });
         cx.subscribe_in(&loader_select_state, window, Self::on_loader_selected).detach();
 
+        let terminal_mode_state = cx.new(|cx| {
+            let items = vec![
+                NamedDropdownItem { name: t::instance::terminal::mode::default().into(), item: None::<bool> },
+                NamedDropdownItem { name: t::instance::terminal::mode::tab().into(), item: Some(true) },
+                NamedDropdownItem { name: t::instance::terminal::mode::window().into(), item: Some(false) },
+            ];
+            let selected = match terminal_in_tab_override {
+                None => 0usize,
+                Some(true) => 1,
+                Some(false) => 2,
+            };
+            SelectState::new(NamedDropdown::new(items), Some(IndexPath::new(selected)), window, cx)
+        });
+        cx.subscribe(&terminal_mode_state, Self::on_terminal_mode_selected).detach();
+
         cx.observe_in(instance, window, |page, instance, window, cx| {
             let entry = instance.read(cx);
             page.instance_root_label = PathLabel::new(entry.root_path.clone(), true);
@@ -229,6 +246,7 @@ impl InstanceSettingsSubpage {
             disable_file_syncing,
             sandbox_available,
             sandbox,
+            terminal_mode_state,
             memory_override_enabled: memory.enabled,
             memory_min_input_state,
             memory_max_input_state,
@@ -469,6 +487,26 @@ impl InstanceSettingsSubpage {
 			id: self.instance_id,
 			account: value.as_ref().map(|value| value.item),
 		});
+    }
+
+    pub fn on_terminal_mode_selected(
+        &mut self,
+        _state: Entity<SelectState<NamedDropdown<Option<bool>>>>,
+        event: &SelectEvent<NamedDropdown<Option<bool>>>,
+        cx: &mut Context<Self>,
+    ) {
+        let SelectEvent::Confirm(value) = event;
+        let value = value.as_ref().map(|item| item.item).unwrap_or(None);
+        // Apply optimistically to the frontend instance so the Terminal tab shows/hides live,
+        // then persist via the backend.
+        self.instance.update(cx, |entry, cx| {
+            entry.configuration.terminal_in_tab = value;
+            cx.notify();
+        });
+        self.backend_handle.send(MessageToBackend::SetInstanceTerminalInTab {
+            id: self.instance_id,
+            value,
+        });
     }
 
     pub fn on_loader_selected(
@@ -856,6 +894,10 @@ impl Render for InstanceSettingsSubpage {
                         sandbox: *value
                     });
                 }))
+            ))
+            .child(crate::labelled(
+                t::instance::terminal::title(),
+                Select::new(&self.terminal_mode_state).w_full(),
             ));
 
         let runtime_content = v_flex()

--- a/crates/frontend/src/pages/instance/terminal_subpage.rs
+++ b/crates/frontend/src/pages/instance/terminal_subpage.rs
@@ -1,0 +1,57 @@
+use gpui::{prelude::*, *};
+use gpui_component::{h_flex, v_flex};
+
+use crate::{entity::instance::InstanceEntry, game_output::GameOutputRoot};
+
+pub struct InstanceTerminalSubpage {
+    output_root: Option<Entity<GameOutputRoot>>,
+    output_entity_id: Option<EntityId>,
+    _observe: Subscription,
+}
+
+impl InstanceTerminalSubpage {
+    pub fn new(
+        instance: &Entity<InstanceEntry>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let current = instance.read(cx).terminal_output.clone();
+        let output_entity_id = current.as_ref().map(|entity| entity.entity_id());
+        let output_root = current.map(|game_output| cx.new(|cx| GameOutputRoot::new_in_tab(game_output, window, cx)));
+
+        // Rebuild the view if a new session is attached while this tab is open (relaunch).
+        let _observe = cx.observe_in(instance, window, |this, instance, window, cx| {
+            let new_output = instance.read(cx).terminal_output.clone();
+            let new_id = new_output.as_ref().map(|entity| entity.entity_id());
+            if new_id != this.output_entity_id {
+                this.output_entity_id = new_id;
+                this.output_root = new_output.map(|game_output| cx.new(|cx| GameOutputRoot::new_in_tab(game_output, window, cx)));
+                cx.notify();
+            }
+        });
+
+        Self {
+            output_root,
+            output_entity_id,
+            _observe,
+        }
+    }
+}
+
+impl Render for InstanceTerminalSubpage {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        let content = if let Some(root) = self.output_root.clone() {
+            root.into_any_element()
+        } else {
+            h_flex()
+                .justify_center()
+                .items_center()
+                .size_full()
+                .text_lg()
+                .child(t::instance::terminal::no_output())
+                .into_any_element()
+        };
+
+        v_flex().p_4().size_full().child(content)
+    }
+}

--- a/crates/frontend/src/processor.rs
+++ b/crates/frontend/src/processor.rs
@@ -196,6 +196,18 @@ impl Processor {
                     cx.new(|cx| Root::new(game_output_root, window, cx))
                 });
             },
+            MessageToFrontend::AttachGameOutput { id, receiver } => {
+                let game_output = cx.new(|cx| GameOutput::new(receiver, cx));
+                // Bind the cloned entity to a `let` first so the `read(cx)` guard is
+                // dropped before `instance.update(cx, …)` re-borrows `cx` mutably.
+                let instance = self.data.instances.read(cx).entries.get(&id).cloned();
+                if let Some(instance) = instance {
+                    instance.update(cx, |instance, cx| {
+                        instance.terminal_output = Some(game_output);
+                        cx.notify();
+                    });
+                }
+            },
             MessageToFrontend::MoveInstanceToTop { id } => {
                 InstanceEntries::move_to_top(&self.data.instances, id, cx);
             },

--- a/crates/schema/src/backend_config.rs
+++ b/crates/schema/src/backend_config.rs
@@ -10,6 +10,8 @@ pub struct BackendConfig {
     #[serde(default, skip_serializing_if = "crate::skip_if_default", deserialize_with = "crate::try_deserialize")]
     pub dont_open_game_output_when_launching: bool,
     #[serde(default, skip_serializing_if = "crate::skip_if_default", deserialize_with = "crate::try_deserialize")]
+    pub terminal_in_tab: bool,
+    #[serde(default, skip_serializing_if = "crate::skip_if_default", deserialize_with = "crate::try_deserialize")]
     pub proxy: ProxyConfig,
 }
 

--- a/crates/schema/src/instance.rs
+++ b/crates/schema/src/instance.rs
@@ -35,6 +35,8 @@ pub struct InstanceConfiguration {
     pub show_shader_tab: bool,
     #[serde(default, deserialize_with = "crate::try_deserialize")]
     pub sandbox: bool, // Default sandbox to false when loading old configuration json
+    #[serde(default, deserialize_with = "crate::try_deserialize", skip_serializing_if = "crate::skip_if_none")]
+    pub terminal_in_tab: Option<bool>,
 }
 
 impl InstanceConfiguration {
@@ -54,7 +56,16 @@ impl InstanceConfiguration {
             disable_file_syncing: false,
             show_shader_tab: false,
             sandbox: false,  // todo: for now, off by default. In the future, turn this on by default
+            terminal_in_tab: None,
         }
+    }
+}
+
+impl InstanceConfiguration {
+    /// Resolve where game output should go for this instance.
+    /// `None` follows the global default; `Some(v)` overrides it.
+    pub fn terminal_in_tab_effective(&self, global: bool) -> bool {
+        self.terminal_in_tab.unwrap_or(global)
     }
 }
 
@@ -314,4 +325,26 @@ fn get_shared_library_path_for_name(name: &str) -> Option<Arc<Path>> {
     }
 
     None
+}
+
+#[cfg(test)]
+mod terminal_in_tab_tests {
+    use super::*;
+
+    #[test]
+    fn effective_follows_global_when_none() {
+        let mut config = InstanceConfiguration::new("1.21".into(), Loader::Vanilla);
+        config.terminal_in_tab = None;
+        assert_eq!(config.terminal_in_tab_effective(true), true);
+        assert_eq!(config.terminal_in_tab_effective(false), false);
+    }
+
+    #[test]
+    fn effective_overrides_global() {
+        let mut config = InstanceConfiguration::new("1.21".into(), Loader::Vanilla);
+        config.terminal_in_tab = Some(true);
+        assert_eq!(config.terminal_in_tab_effective(false), true);
+        config.terminal_in_tab = Some(false);
+        assert_eq!(config.terminal_in_tab_effective(true), false);
+    }
 }

--- a/crates/t/locales.toml
+++ b/crates/t/locales.toml
@@ -2737,3 +2737,45 @@ ru = "м"
 [time.s]
 en = "s"
 ru = "с"
+
+[settings.windows.terminal_in_tab]
+en = "Open game output in tab instead"
+de = "Spielausgabe stattdessen im Tab öffnen"
+hu = "Játéknapló megnyitása lapon helyette"
+ru = "Открывать логи игры во вкладке"
+sv = "Öppna spelutdata i flik istället"
+
+[instance.terminal.title]
+en = "Game Output"
+de = "Spielausgabe"
+hu = "Játéknapló"
+ru = "Логи игры"
+sv = "Spelutdata"
+
+[instance.terminal.no_output]
+en = "No output yet"
+de = "Noch keine Ausgabe"
+hu = "Még nincs kimenet"
+ru = "Пока нет вывода"
+sv = "Ingen utdata än"
+
+[instance.terminal.mode.default]
+en = "Default (global)"
+de = "Standard (global)"
+hu = "Alapértelmezett (globális)"
+ru = "По умолчанию (глобально)"
+sv = "Standard (global)"
+
+[instance.terminal.mode.tab]
+en = "Always in tab"
+de = "Immer im Tab"
+hu = "Mindig lapon"
+ru = "Всегда во вкладке"
+sv = "Alltid i flik"
+
+[instance.terminal.mode.window]
+en = "Always in window"
+de = "Immer im Fenster"
+hu = "Mindig ablakban"
+ru = "Всегда в окне"
+sv = "Alltid i fönster"

--- a/crates/t/src/lib.rs
+++ b/crates/t/src/lib.rs
@@ -3107,6 +3107,72 @@ pub mod instance {
             }
         }
     }
+    #[rustfmt::skip]
+    pub mod terminal {
+        pub fn get(key: &str) -> Option<&'static str> {
+            match key {
+                "no_output" => Some(no_output()),
+                "title" => Some(title()),
+                _ => None,
+            }
+        }
+        #[rustfmt::skip]
+        pub mod mode {
+            pub fn get(key: &str) -> Option<&'static str> {
+                match key {
+                    "default" => Some(default()),
+                    "tab" => Some(tab()),
+                    "window" => Some(window()),
+                    _ => None,
+                }
+            }
+            pub fn default() -> &'static str {
+                match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
+                    1 => "Standard (global)",
+                    2 => "Alapértelmezett (globális)",
+                    3 => "По умолчанию (глобально)",
+                    4 => "Standard (global)",
+                    _ => "Default (global)",
+                }
+            }
+            pub fn tab() -> &'static str {
+                match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
+                    1 => "Immer im Tab",
+                    2 => "Mindig lapon",
+                    3 => "Всегда во вкладке",
+                    4 => "Alltid i flik",
+                    _ => "Always in tab",
+                }
+            }
+            pub fn window() -> &'static str {
+                match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
+                    1 => "Immer im Fenster",
+                    2 => "Mindig ablakban",
+                    3 => "Всегда в окне",
+                    4 => "Alltid i fönster",
+                    _ => "Always in window",
+                }
+            }
+        }
+        pub fn no_output() -> &'static str {
+            match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
+                1 => "Noch keine Ausgabe",
+                2 => "Még nincs kimenet",
+                3 => "Пока нет вывода",
+                4 => "Ingen utdata än",
+                _ => "No output yet",
+            }
+        }
+        pub fn title() -> &'static str {
+            match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
+                1 => "Spielausgabe",
+                2 => "Játéknapló",
+                3 => "Логи игры",
+                4 => "Spelutdata",
+                _ => "Game Output",
+            }
+        }
+    }
     pub fn title() -> &'static str {
         match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
             1 => "Instanzen",
@@ -4686,6 +4752,7 @@ pub mod settings {
                 "close_all_when_main_closed" => Some(close_all_when_main_closed()),
                 "hide_main_window" => Some(hide_main_window()),
                 "open_game_output" => Some(open_game_output()),
+                "terminal_in_tab" => Some(terminal_in_tab()),
                 "title" => Some(title()),
                 "use_os_titlebar" => Some(use_os_titlebar()),
                 _ => None,
@@ -4716,6 +4783,15 @@ pub mod settings {
                 3 => "Открывать логи игры при запуске",
                 4 => "Öppna spelutdata vid spelstart",
                 _ => "Open game output on launch",
+            }
+        }
+        pub fn terminal_in_tab() -> &'static str {
+            match crate::LANG.load(std::sync::atomic::Ordering::Relaxed) {
+                1 => "Spielausgabe stattdessen im Tab öffnen",
+                2 => "Játéknapló megnyitása lapon helyette",
+                3 => "Открывать логи игры во вкладке",
+                4 => "Öppna spelutdata i flik istället",
+                _ => "Open game output in tab instead",
             }
         }
         pub fn title() -> &'static str {


### PR DESCRIPTION
Route Minecraft game output into an in-app "Game Output" tab on the instance page instead of a separate window, controlled by a global setting (frontend InterfaceConfig) with a per-instance tri-state override (Default / Always in tab / Always in window). The backend routes window vs. tab at launch for all launch paths; the frontend holds each instance's output and shows the tab live based on the effective setting. Reuses the existing game-output renderer and adds en/de/hu/ru/sv strings.

<img width="1258" height="758" alt="image" src="https://github.com/user-attachments/assets/942ef642-9e55-444d-bc18-432bff1f8ca7" />
<img width="723" height="1359" alt="image" src="https://github.com/user-attachments/assets/706f4bd9-fa8a-4ced-97b4-c1674a1b9c77" />
