### PR TITLE
Fix curseforge mods not updating when clicking update all

### DIFF
--- a/crates/bridge/src/instance.rs
+++ b/crates/bridge/src/instance.rs
@@ -305,8 +305,8 @@ pub enum ContentUpdateStatus {
 impl ContentUpdateStatus {
     pub fn can_update(&self) -> bool {
         match self {
-            ContentUpdateStatus::Modrinth => true,
-            _ => false,
+            ContentUpdateStatus::Modrinth | ContentUpdateStatus::Curseforge => true,
+            ContentUpdateStatus::Unknown | ContentUpdateStatus::ManualInstall | ContentUpdateStatus::ErrorNotFound | ContentUpdateStatus::ErrorInvalidHash | ContentUpdateStatus::AlreadyUpToDate => false,
         }
     }
 }


### PR DESCRIPTION
`can_update` was returning true only for modrinth