### PR TITLE
Fix loading spinner staying on update error

### DIFF
--- a/crates/frontend/src/component/content_list.rs
+++ b/crates/frontend/src/component/content_list.rs
@@ -260,22 +260,20 @@ impl ContentListDelegate {
                                 return;
                             }
 
-                            let mut updating = updating.lock();
                             let delegate = this.delegate_mut();
                             if delegate.is_selected(element_id) {
                                 for summary in &delegate.content {
                                     if delegate.is_selected(summary.filename_hash) && summary.update.can_update(delegate.for_loader, delegate.for_version.as_str()) {
-                                        updating.insert(summary.filename_hash);
-                                        crate::root::update_single_mod(id, summary.id, &backend_handle, window, cx);
+                                        crate::root::update_single_mod(id, summary.id, summary.filename_hash, &updating, &backend_handle, window, cx);
                                     }
                                 }
                                 delegate.selected.clear();
                                 delegate.selected_range.clear();
                                 delegate.last_clicked_non_range = None;
                             } else {
-                                updating.insert(element_id);
-                                crate::root::update_single_mod(id, content_id, &backend_handle, window, cx);
+                                crate::root::update_single_mod(id, content_id, element_id, &updating, &backend_handle, window, cx);
                             }
+                            cx.notify();
                         }))
                 )
             },

--- a/crates/frontend/src/modals/change_version.rs
+++ b/crates/frontend/src/modals/change_version.rs
@@ -665,10 +665,9 @@ impl ChangeVersionDialog {
                         files: vec![install_file].into(),
                     };
 
-                    updating.lock().insert(filename_hash);
+                    root::change_mod_version(content_install, filename_hash, &updating, &backend_handle, window, cx);
                     content_list.update(cx, |_, cx| cx.notify());
                     window.close_dialog(cx);
-                    root::start_install(content_install, &backend_handle, window, cx);
                 }
             }));
 

--- a/crates/frontend/src/pages/instance/content_subpage.rs
+++ b/crates/frontend/src/pages/instance/content_subpage.rs
@@ -352,19 +352,12 @@ impl Render for InstanceContentSubpage {
                     .on_click({
                         cx.listener(move |page, _, window, cx| {
                             if let Some(content) = page.content.read(cx).clone() {
-                                let hashes: Vec<u64> = content.iter()
-                                    .filter(|summary| summary.update.can_update(page.instance_loader, page.instance_version.as_str()))
-                                    .map(|summary| summary.filename_hash)
-                                    .collect();
-
-                                page.updating.lock().extend(hashes.iter());
-                                page.content_list.update(cx, |_, cx| cx.notify());
-
                                 for summary in content.iter() {
                                     if summary.update.can_update(page.instance_loader, page.instance_version.as_str()) {
-                                        crate::root::update_single_mod(page.instance, summary.id, &page.backend_handle, window, cx);
+                                        crate::root::update_single_mod(page.instance, summary.id, summary.filename_hash, &page.updating, &page.backend_handle, window, cx);
                                     }
                                 }
+                                page.content_list.update(cx, |_, cx| cx.notify());
                             }
                         })
                     }))

--- a/crates/frontend/src/root.rs
+++ b/crates/frontend/src/root.rs
@@ -1,5 +1,7 @@
 use std::{path::Path, sync::{Arc, atomic::AtomicBool}};
 
+use parking_lot::Mutex;
+
 use bridge::{
     handle::BackendHandle,
     install::ContentInstall,
@@ -9,6 +11,7 @@ use bridge::{
 };
 use gpui::{prelude::*, *};
 use gpui_component::{Root, Theme, WindowExt, scroll::ScrollableElement, v_flex};
+use rustc_hash::FxHashSet;
 
 use crate::{Backwards, CloseWindow, Forwards, MAIN_FONT, OpenSettings, entity::DataEntities, game_output::{GameOutput, GameOutputRoot}, interface_config::{InterfaceConfig, LiveGameOutputDisplay}, modals, pages::instance::instance_page::InstanceSubpageType, ui::{LauncherUI, PageType}};
 
@@ -248,6 +251,39 @@ pub fn start_install(
     modals::generic::show_notification(window, cx, t::instance::content::install::error().into(), modal_action);
 }
 
+pub fn change_mod_version(
+    content_install: ContentInstall,
+    hash: u64,
+    updating: &Arc<Mutex<FxHashSet<u64>>>,
+    backend_handle: &BackendHandle,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    updating.lock().insert(hash);
+
+    let modal_action = ModalAction::default();
+
+    backend_handle.send(MessageToBackend::InstallContent {
+        content: content_install.clone(),
+        modal_action: modal_action.clone(),
+    });
+
+    let notify = modal_action.get_notify();
+    let updating = updating.clone();
+    let modal_action_clone = modal_action.clone();
+    window.spawn(cx, async move |_| {
+        loop {
+            notify.notified().await;
+            if modal_action_clone.get_finished_at().is_some() {
+                break;
+            }
+        }
+        updating.lock().remove(&hash);
+    }).detach();
+
+    modals::generic::show_notification(window, cx, t::instance::content::install::error().into(), modal_action);
+}
+
 pub fn start_update_check(
     instance: InstanceID,
     backend_handle: &BackendHandle,
@@ -268,10 +304,14 @@ pub fn start_update_check(
 pub fn update_single_mod(
     instance: InstanceID,
     mod_id: InstanceContentID,
+    hash: u64,
+    updating: &Arc<Mutex<FxHashSet<u64>>>,
     backend_handle: &BackendHandle,
     window: &mut Window,
     cx: &mut App,
 ) {
+    updating.lock().insert(hash);
+
     let modal_action = ModalAction::default();
 
     backend_handle.send(MessageToBackend::UpdateContent {
@@ -279,6 +319,19 @@ pub fn update_single_mod(
         content_id: mod_id,
         modal_action: modal_action.clone(),
     });
+
+    let notify = modal_action.get_notify();
+    let updating = updating.clone();
+    let modal_action_clone = modal_action.clone();
+    window.spawn(cx, async move |_| {
+        loop {
+            notify.notified().await;
+            if modal_action_clone.get_finished_at().is_some() {
+                break;
+            }
+        }
+        updating.lock().remove(&hash);
+    }).detach();
 
     modals::generic::show_notification(window, cx, t::instance::content::update::download::error().into(), modal_action);
 }


### PR DESCRIPTION
When update fails, `updating.retain` will retain the loading state since filename hash does not change. Bug image:
<img width="468" height="290" src="https://github.com/user-attachments/assets/12f1f4e0-affc-4b39-be6b-3c62a6abe2ee" />

Clears loading state when update either finishes or fails. Not sure, maybe there's a better way to fix this...